### PR TITLE
Add PANOC + change on iterator structure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.jl.cov
 *.jl.*.cov
 *.jl.mem
+*.swp

--- a/src/ProximalAlgorithms.jl
+++ b/src/ProximalAlgorithms.jl
@@ -10,28 +10,29 @@ include("utilities/identity.jl")
 include("utilities/zero.jl")
 include("utilities/conjugate.jl")
 
-abstract type ProximalAlgorithm{I, T} end
+abstract type ProximalAlgorithm{I} end
 
 # The following methods give `ProximalAlgorithm` objects the iterable behavior.
 
-function start(solver::ProximalAlgorithm{I, T})::I where {I, T}
-    initialize(solver)
+function start(solver::ProximalAlgorithm{I})::I where {I}
+    initialize!(solver)
     return zero(I)
 end
 
-function next(solver::ProximalAlgorithm{I, T}, it::I)::Tuple{T, I} where {I, T}
-    point::T = iterate(solver, it)
-    return (point, it + one(I))
+function next(solver::ProximalAlgorithm{I}, it::I)::Tuple{Void, I} where {I}
+    iterate!(solver, it)
+    return (nothing, it + one(I))
 end
 
-function done(solver::ProximalAlgorithm{I, T}, it::I)::Bool where {I, T}
+function done(solver::ProximalAlgorithm{I}, it::I)::Bool where {I}
     return it >= maxit(solver) || converged(solver, it)
 end
 
 # Running a `ProximalAlgorithm` unrolls the iterations
 
-function run(solver::ProximalAlgorithm{I, T})::Tuple{I, T} where {I, T}
-    local it, point
+function run!(solver::ProximalAlgorithm{I})::I where {I}
+    local it = zero(I)
+    local point = nothing
     if verbose(solver) display(solver) end
     # NOTE: the following loop is translated into:
     #   it = start(solver)
@@ -44,7 +45,7 @@ function run(solver::ProximalAlgorithm{I, T})::Tuple{I, T} where {I, T}
         if verbose(solver, it) display(solver, it) end
     end
     if verbose(solver) display(solver, it) end
-    return (it, point)
+    return it
 end
 
 # Functions `verbose` and `display` are used for inspecting the iterations.
@@ -56,7 +57,7 @@ function display(sol::ProximalAlgorithm) end
 function display(sol::ProximalAlgorithm, it) end
 
 # It remains to define what concrete ProximalAlgorithm types are and how
-# `initialize`, `iterate`, `maxit`, `converged` work for each specific solver.
+# `initialize!`, `iterate!`, `maxit`, `converged` work for each specific solver.
 # This is done in the following included files.
 
 include("algorithms/ForwardBackward.jl")

--- a/src/ProximalAlgorithms.jl
+++ b/src/ProximalAlgorithms.jl
@@ -10,29 +10,28 @@ include("utilities/identity.jl")
 include("utilities/zero.jl")
 include("utilities/conjugate.jl")
 
-abstract type ProximalAlgorithm{I} end
+abstract type ProximalAlgorithm{I,T} end
 
 # The following methods give `ProximalAlgorithm` objects the iterable behavior.
 
-function start(solver::ProximalAlgorithm{I})::I where {I}
+function start(solver::ProximalAlgorithm{I,T})::I where {I,T}
     initialize!(solver)
     return zero(I)
 end
 
-function next(solver::ProximalAlgorithm{I}, it::I)::Tuple{Void, I} where {I}
-    iterate!(solver, it)
-    return (nothing, it + one(I))
+function next(solver::ProximalAlgorithm{I,T}, it::I)::Tuple{T, I} where {I,T}
+    point = iterate!(solver, it)
+    return (point, it + one(I))
 end
 
-function done(solver::ProximalAlgorithm{I}, it::I)::Bool where {I}
+function done(solver::ProximalAlgorithm{I,T}, it::I)::Bool where {I,T}
     return it >= maxit(solver) || converged(solver, it)
 end
 
 # Running a `ProximalAlgorithm` unrolls the iterations
 
-function run!(solver::ProximalAlgorithm{I})::I where {I}
-    local it = zero(I)
-    local point = nothing
+function run!(solver::ProximalAlgorithm{I,T})::Tuple{I,T} where {I,T}
+    local it, point
     if verbose(solver) display(solver) end
     # NOTE: the following loop is translated into:
     #   it = start(solver)
@@ -45,7 +44,7 @@ function run!(solver::ProximalAlgorithm{I})::I where {I}
         if verbose(solver, it) display(solver, it) end
     end
     if verbose(solver) display(solver, it) end
-    return it
+    return it, point
 end
 
 # Functions `verbose` and `display` are used for inspecting the iterations.

--- a/src/ProximalAlgorithms.jl
+++ b/src/ProximalAlgorithms.jl
@@ -61,6 +61,7 @@ function display(sol::ProximalAlgorithm, it) end
 
 include("algorithms/ForwardBackward.jl")
 include("algorithms/ZeroFPR.jl")
+include("algorithms/PANOC.jl")
 include("algorithms/DouglasRachford.jl")
 include("algorithms/AsymmetricForwardBackwardAdjoint.jl")
 

--- a/src/algorithms/AsymmetricForwardBackwardAdjoint.jl
+++ b/src/algorithms/AsymmetricForwardBackwardAdjoint.jl
@@ -232,12 +232,6 @@ function AFBA(x0, y0; kwargs...)
     # Create iterable
     sol = AFBAIterator(x0, y0; kwargs...)
     # Run iterations
-    return AFBA!(sol)
-end
-
-# in-place interface
-function AFBA!(sol::AFBAIterator)
-    # Run iterations
     (it, (primal, dual)) = run!(sol)
     return (it, primal, dual, sol)
 end
@@ -263,7 +257,8 @@ function VuCondat(x0, y0; kwargs...)
     # Create iterable
     sol = AFBAIterator(x0, y0; kwargs..., theta=2)
     # Run iterations
-    return AFBA!(sol)
+    (it, (primal, dual)) = run!(sol)
+    return (it, primal, dual, sol)
 end
 
 """
@@ -286,5 +281,6 @@ function ChambollePock(x0, y0; kwargs...)
     # Create iterable
     sol = AFBAIterator(x0, y0; kwargs..., f=IndFree(), theta=2)
     # Run iterations
-    return AFBA!(sol)
+    (it, (primal, dual)) = run!(sol)
+    return (it, primal, dual, sol)
 end

--- a/src/algorithms/AsymmetricForwardBackwardAdjoint.jl
+++ b/src/algorithms/AsymmetricForwardBackwardAdjoint.jl
@@ -187,12 +187,17 @@ end
 
 """
 **Asymmetric forward-backward-adjoint algorithm**
+
     AFBA(x0, y0; kwargs)
+
 Solves convex optimization problems of the form
+
     minimize f(x) + g(x) + (h □ l)(L x),
+
 where `f` is smooth, `g` and `h` are possibly nonsmooth and `l` is strongly convex.
 Symbol `□` denotes the infimal convolution, and `L` is a linear mapping.
 Points `x0` and `y0` are the initial primal and dual iterates, respectively.
+
 Keyword arguments are as follows:
 * `f`: smooth, convex function (default: zero)
 * `g`: convex function (possibly nonsmooth, default: zero)
@@ -209,12 +214,15 @@ Keyword arguments are as follows:
 * `maxit`: maximum number of iterations (default: `10000`)
 * `verbose`, verbosity level (default: `1`)
 * `verbose_freq`, verbosity frequency for `verbose = 1` (default: `100`)
+
 The iterator implements Algorithm 3 of [1] with constant stepsize (α_n=λ) for several prominant special cases:
 1) θ = 2 	 	==>   Corresponds to the Vu-Condat Algorithm [2,3].
 2) θ = 1, μ=1
 3) θ = 0, μ=1
 4) θ ∈ [0,∞), μ=0
+
 See [1, Figure 1] for other special cases and relation to other algorithms.
+
 [1] Latafat, Patrinos. "Asymmetric forward–backward–adjoint splitting for solving monotone inclusions involving three operators"  Computational Optimization and Applications, pages 1–37, 2017.
 [2] Condat. "A primal–dual splitting method for convex optimization involving Lipschitzian, proximable and linear composite terms" Journal of Optimization Theory and Applications 158.2 (2013): 460-479.
 [3] Vũ. "A splitting algorithm for dual monotone inclusions involving cocoercive operators"" Advances in Computational Mathematics, 38(3), pp.667-681.
@@ -236,12 +244,18 @@ end
 
 """
 **Vũ-Condat primal-dual algorithm**
+
     VuCondat(x0, y0; kwargs)
+
 Solves convex optimization problems of the form
+
     minimize f(x) + g(x) + (h □ l)(L x).
+
 where `f` is smooth, `g` and `h` are possibly nonsmooth and `l` is strongly convex.
+
 Symbol `□` denotes the infimal convolution, and `L` is a linear mapping.
 Points `x0` and `y0` are the initial primal and dual iterates, respectively.
+
 See documentation of `AFBA` for the list of keyword arguments.
 """
 
@@ -254,12 +268,17 @@ end
 
 """
 **Chambolle-Pock primal-dual algorithm**
+
     ChambollePock(x0, y0; kwargs)
+
 Solves convex optimization problems of the form
+
     minimize g(x) + (h □ l)(L x).
+
 where `g` and `h` are possibly nonsmooth and `l` is strongly convex.
 Symbol `□` denotes the infimal convolution, and `L` is a linear mapping.
 Points `x0` and `y0` are the initial primal and dual iterates, respectively.
+
 See documentation of `AFBA` for the list of keyword arguments.
 """
 

--- a/src/algorithms/DouglasRachford.jl
+++ b/src/algorithms/DouglasRachford.jl
@@ -5,7 +5,7 @@
 # [1] Eckstein, Bertsekas "On the Douglas-Rachford Splitting Method and the Proximal Point Algorithm for Maximal Monotone Operators*", Mathematical Programming, vol. 55, no. 1, pp. 293-318 (1989).
 #
 
-struct DRSIterator{I <: Integer, R <: Real, T <: BlockArray{R}} <: ProximalAlgorithm{I, T}
+struct DRSIterator{I <: Integer, R <: Real, T <: BlockArray{R}} <: ProximalAlgorithm{I}
     x::T
     f
     g
@@ -60,20 +60,19 @@ end
 ################################################################################
 # Initialization
 
-function initialize(sol::DRSIterator)
+function initialize!(sol::DRSIterator)
     return
 end
 
 ################################################################################
 # Iteration
 
-function iterate(sol::DRSIterator{I, T}, it::I) where {I, T}
+function iterate!(sol::DRSIterator{I, T}, it::I) where {I, T}
     prox!(sol.y, sol.f, sol.x, sol.gamma)
     sol.r .= 2.*sol.y .- sol.x
     prox!(sol.z, sol.g, sol.r, sol.gamma)
     sol.FPR_x .= sol.y .- sol.z
     sol.x .-= sol.FPR_x
-    return sol.z
 end
 
 ################################################################################
@@ -81,6 +80,10 @@ end
 
 function DRS(x0; kwargs...)
     sol = DRSIterator(x0; kwargs...)
-    (it, point) = run(sol)
-    return (it, point, sol)
+    return DRS!(sol)
+end
+
+function DRS!(sol::DRSIterator)
+    it = run!(sol)
+    return (it, sol.z, sol)
 end

--- a/src/algorithms/DouglasRachford.jl
+++ b/src/algorithms/DouglasRachford.jl
@@ -5,7 +5,7 @@
 # [1] Eckstein, Bertsekas "On the Douglas-Rachford Splitting Method and the Proximal Point Algorithm for Maximal Monotone Operators*", Mathematical Programming, vol. 55, no. 1, pp. 293-318 (1989).
 #
 
-struct DRSIterator{I <: Integer, R <: Real, T <: BlockArray{R}} <: ProximalAlgorithm{I}
+struct DRSIterator{I <: Integer, R <: Real, T <: BlockArray{R}} <: ProximalAlgorithm{I,T}
     x::T
     f
     g
@@ -37,7 +37,7 @@ end
 
 maxit(sol::DRSIterator) = sol.maxit
 
-converged(sol::DRSIterator, it) = blockmaxabs(sol.FPR_x)/sol.gamma <= sol.tol
+converged(sol::DRSIterator, it) = it > 0 && blockmaxabs(sol.FPR_x)/sol.gamma <= sol.tol
 
 verbose(sol::DRSIterator) = sol.verbose > 0
 verbose(sol::DRSIterator, it) = sol.verbose > 0 && (sol.verbose == 2 ? true : (it == 1 || it%sol.verbose_freq == 0))
@@ -73,6 +73,7 @@ function iterate!(sol::DRSIterator{I, T}, it::I) where {I, T}
     prox!(sol.z, sol.g, sol.r, sol.gamma)
     sol.FPR_x .= sol.y .- sol.z
     sol.x .-= sol.FPR_x
+    return sol.z
 end
 
 ################################################################################
@@ -84,6 +85,6 @@ function DRS(x0; kwargs...)
 end
 
 function DRS!(sol::DRSIterator)
-    it = run!(sol)
-    return (it, sol.z, sol)
+    it, point = run!(sol)
+    return (it, point, sol)
 end

--- a/src/algorithms/DouglasRachford.jl
+++ b/src/algorithms/DouglasRachford.jl
@@ -81,10 +81,6 @@ end
 
 function DRS(x0; kwargs...)
     sol = DRSIterator(x0; kwargs...)
-    return DRS!(sol)
-end
-
-function DRS!(sol::DRSIterator)
     it, point = run!(sol)
     return (it, point, sol)
 end

--- a/src/algorithms/ForwardBackward.jl
+++ b/src/algorithms/ForwardBackward.jl
@@ -47,7 +47,7 @@ function FBSIterator(x0::T; fs=Zero(), As=Identity(blocksize(x0)), fq=Zero(), Aq
     n = blocksize(x0)
     mq = size(Aq, 1)
     ms = size(As, 1)
-    x = blockcopy(x0)
+    x = x0
     y = blockzeros(x0)
     z = blockzeros(x0)
     z_prev = blockzeros(x0)
@@ -68,7 +68,17 @@ end
 
 maxit(sol::FBSIterator) = sol.maxit
 
-converged(sol::FBSIterator, it) = it > 0 && blockmaxabs(sol.FPR_x)/sol.gamma <= sol.tol
+function converged(sol::FBSIterator, it) 
+	cnv = it > 0 && blockmaxabs(sol.FPR_x)/sol.gamma <= sol.tol
+	if cnv
+		blockset!(sol.x,sol.z)
+		if isodd(it) && !sol.fast
+			# make sure x0 is x to warm start correctly
+			sol.x, sol.z = sol.z, sol.x
+		end
+	end
+	return cnv
+end
 
 verbose(sol::FBSIterator) = sol.verbose > 0
 verbose(sol::FBSIterator, it) = sol.verbose > 0 && (sol.verbose == 2 ? true : (it == 1 || it%sol.verbose_freq == 0))
@@ -92,6 +102,9 @@ end
 # Initialization
 
 function initialize!(sol::FBSIterator)
+
+    # reset parameters
+    sol.theta = 1.0
 
     # compute first forward-backward step here
     A_mul_B!(sol.Aqx, sol.Aq, sol.x)

--- a/src/algorithms/ForwardBackward.jl
+++ b/src/algorithms/ForwardBackward.jl
@@ -47,7 +47,7 @@ function FBSIterator(x0::T; fs=Zero(), As=Identity(blocksize(x0)), fq=Zero(), Aq
     n = blocksize(x0)
     mq = size(Aq, 1)
     ms = size(As, 1)
-    x = x0
+    x = blockcopy(x0)
     y = blockzeros(x0)
     z = blockzeros(x0)
     z_prev = blockzeros(x0)
@@ -68,17 +68,7 @@ end
 
 maxit(sol::FBSIterator) = sol.maxit
 
-function converged(sol::FBSIterator, it) 
-	cnv = it > 0 && blockmaxabs(sol.FPR_x)/sol.gamma <= sol.tol
-	if cnv
-		blockset!(sol.x,sol.z)
-		if isodd(it) && !sol.fast
-			# make sure x0 is x to warm start correctly
-			sol.x, sol.z = sol.z, sol.x
-		end
-	end
-	return cnv
-end
+converged(sol::FBSIterator, it)  = it > 0 && blockmaxabs(sol.FPR_x)/sol.gamma <= sol.tol
 
 verbose(sol::FBSIterator) = sol.verbose > 0
 verbose(sol::FBSIterator, it) = sol.verbose > 0 && (sol.verbose == 2 ? true : (it == 1 || it%sol.verbose_freq == 0))

--- a/src/algorithms/ForwardBackward.jl
+++ b/src/algorithms/ForwardBackward.jl
@@ -8,7 +8,7 @@
 # [2] Tseng, "On Accelerated Proximal Gradient Methods for Convex-Concave Optimization," (2008)
 #
 
-mutable struct FBSIterator{I <: Integer, R <: Real, T <: BlockArray{R}} <: ProximalAlgorithm{I}
+mutable struct FBSIterator{I <: Integer, R <: Real, T <: BlockArray{R}} <: ProximalAlgorithm{I, T}
     x::T
     fs
     As
@@ -68,7 +68,7 @@ end
 
 maxit(sol::FBSIterator) = sol.maxit
 
-converged(sol::FBSIterator, it) = blockmaxabs(sol.FPR_x)/sol.gamma <= sol.tol
+converged(sol::FBSIterator, it) = it > 0 && blockmaxabs(sol.FPR_x)/sol.gamma <= sol.tol
 
 verbose(sol::FBSIterator) = sol.verbose > 0
 verbose(sol::FBSIterator, it) = sol.verbose > 0 && (sol.verbose == 2 ? true : (it == 1 || it%sol.verbose_freq == 0))
@@ -211,7 +211,7 @@ function iterate!(sol::FBSIterator{I, R, T}, it::I) where {I, R, T}
     prox!(sol.z, sol.g, sol.y, sol.gamma)
     blockaxpy!(sol.FPR_x, sol.x, -1.0, sol.z)
 
-    return 
+    return sol.z
 
 end
 
@@ -251,6 +251,6 @@ function FBS(x0; kwargs...)
 end
 
 function FBS!(sol::FBSIterator)
-    it = run!(sol)
-    return (it, sol.z, sol)
+    it, point = run!(sol)
+    return (it, point, sol)
 end

--- a/src/algorithms/ForwardBackward.jl
+++ b/src/algorithms/ForwardBackward.jl
@@ -247,10 +247,6 @@ additional options as follows:
 
 function FBS(x0; kwargs...)
     sol = FBSIterator(x0; kwargs...)
-    return FBS!(sol)
-end
-
-function FBS!(sol::FBSIterator)
     it, point = run!(sol)
     return (it, point, sol)
 end

--- a/src/algorithms/ForwardBackward.jl
+++ b/src/algorithms/ForwardBackward.jl
@@ -8,7 +8,7 @@
 # [2] Tseng, "On Accelerated Proximal Gradient Methods for Convex-Concave Optimization," (2008)
 #
 
-mutable struct FBSIterator{I <: Integer, R <: Real, T <: BlockArray{R}} <: ProximalAlgorithm{I, T}
+mutable struct FBSIterator{I <: Integer, R <: Real, T <: BlockArray{R}} <: ProximalAlgorithm{I}
     x::T
     fs
     As
@@ -91,7 +91,7 @@ end
 ################################################################################
 # Initialization
 
-function initialize(sol::FBSIterator)
+function initialize!(sol::FBSIterator)
 
     # compute first forward-backward step here
     A_mul_B!(sol.Aqx, sol.Aq, sol.x)
@@ -127,7 +127,7 @@ end
 ################################################################################
 # Iteration
 
-function iterate(sol::FBSIterator{I, R, T}, it) where {I, R, T}
+function iterate!(sol::FBSIterator{I, R, T}, it::I) where {I, R, T}
 
     Aqz = 0.0
     gradfq_Aqz = 0.0
@@ -211,7 +211,7 @@ function iterate(sol::FBSIterator{I, R, T}, it) where {I, R, T}
     prox!(sol.z, sol.g, sol.y, sol.gamma)
     blockaxpy!(sol.FPR_x, sol.x, -1.0, sol.z)
 
-    return sol.z
+    return 
 
 end
 
@@ -247,6 +247,10 @@ additional options as follows:
 
 function FBS(x0; kwargs...)
     sol = FBSIterator(x0; kwargs...)
-    (it, point) = run(sol)
-    return (it, point, sol)
+    return FBS!(sol)
+end
+
+function FBS!(sol::FBSIterator)
+    it = run!(sol)
+    return (it, sol.z, sol)
 end

--- a/src/algorithms/PANOC.jl
+++ b/src/algorithms/PANOC.jl
@@ -60,11 +60,11 @@ function PANOCIterator(x0::T; fs=Zero(), As=Identity(blocksize(x0)), fq=Zero(), 
     n = blocksize(x0)
     mq = size(Aq, 1)
     ms = size(As, 1)
-    x       = x0
+    x       = blockcopy(x0)
     xbar    = blockzeros(x0)
-    x_prev  = blockcopy(x0)
-    xnew    = blockcopy(x0)
-    xnewbar = blockcopy(x0)
+    x_prev  = blockzeros(x0)
+    xnew    = blockzeros(x0)
+    xnewbar = blockzeros(x0)
     y = blockzeros(x0)
     FPR_x = blockzeros(x0)
     FPR_x_prev = blockzeros(x0)
@@ -110,17 +110,7 @@ end
 
 maxit(sol::PANOCIterator) = sol.maxit
 
-function converged(sol::PANOCIterator, it) 
-	cnv = it > 0 && blockmaxabs(sol.FPR_x)/sol.gamma <= sol.tol
-	if cnv
-		if isodd(it)
-			# make sure x0 is x to warm start correctly
-			sol.x, sol.xnew = sol.xnew, sol.x 
-		end
-		blockset!(sol.x,sol.xbar)
-	end
-	return cnv
-end
+converged(sol::PANOCIterator, it) = it > 0 && blockmaxabs(sol.FPR_x)/sol.gamma <= sol.tol
 
 verbose(sol::PANOCIterator) = sol.verbose > 0 
 verbose(sol::PANOCIterator, it) = sol.verbose > 0 && (sol.verbose == 2 ? true : (it == 1 || it%sol.verbose_freq == 0))

--- a/src/algorithms/PANOC.jl
+++ b/src/algorithms/PANOC.jl
@@ -1,7 +1,7 @@
 ################################################################################
 # PANOC iterator (with L-BFGS directions)
 
-mutable struct PANOCIterator{I <: Integer, R <: Real, T <: BlockArray} <: ProximalAlgorithm{I, T}
+mutable struct PANOCIterator{I <: Integer, R <: Real, T <: BlockArray} <: ProximalAlgorithm{I}
     x::T
     fs
     As
@@ -85,7 +85,7 @@ end
 ################################################################################
 # Initialization
 
-function initialize(sol::PANOCIterator)
+function initialize!(sol::PANOCIterator)
 
     # compute first forward-backward step here
     A_mul_B!(sol.Aqx, sol.Aq, sol.x)
@@ -121,7 +121,7 @@ end
 ################################################################################
 # Iteration
 
-function iterate(sol::PANOCIterator{I, R, T}, it) where {I, R, T}
+function iterate!(sol::PANOCIterator{I, R, T}, it::I) where {I, R, T}
 
     # These need to be performed anyway (to compute xbarbar later on)
     Aqxbar = sol.Aq*sol.xbar
@@ -228,7 +228,7 @@ function iterate(sol::PANOCIterator{I, R, T}, it) where {I, R, T}
     sol.FPR_xbar_prev = FPR_xbar
     sol.xbar = xnewbar
 
-    return sol.xbar
+    return 
 
 end
 
@@ -237,6 +237,10 @@ end
 
 function PANOC(x0; kwargs...)
     sol = PANOCIterator(x0; kwargs...)
-    (it, point) = run(sol)
-    return (it, point, sol)
+    return PANOC!(sol)
+end
+
+function PANOC!(sol::PANOCIterator)
+    it = run!(sol)
+    return (it, sol.xbar, sol)
 end

--- a/src/algorithms/PANOC.jl
+++ b/src/algorithms/PANOC.jl
@@ -237,10 +237,6 @@ end
 
 function PANOC(x0; kwargs...)
     sol = PANOCIterator(x0; kwargs...)
-    return PANOC!(sol)
-end
-
-function PANOC!(sol::PANOCIterator)
     it, point = run!(sol)
     return (it, point, sol)
 end

--- a/src/algorithms/PANOC.jl
+++ b/src/algorithms/PANOC.jl
@@ -1,0 +1,242 @@
+################################################################################
+# PANOC iterator (with L-BFGS directions)
+
+mutable struct PANOCIterator{I <: Integer, R <: Real, T <: BlockArray} <: ProximalAlgorithm{I, T}
+    x::T
+    fs
+    As
+    fq
+    Aq
+    g
+    gamma::R
+    maxit::I
+    tol::R
+    adaptive::Bool
+    verbose::I
+    verbose_freq::I
+    alpha::R
+    sigma::R
+    tau::R
+    y # gradient step
+    xbar # proximal-gradient step
+    H # inverse Jacobian approximation
+    FPR_x
+    Aqx
+    Asx
+    gradfq_Aqx
+    gradfs_Asx
+    fs_Asx
+    fq_Aqx
+    f_Ax
+    At_gradf_Ax
+    g_xbar
+    FBE_x
+    xbar_prev
+    FPR_xbar_prev
+    d
+end
+
+################################################################################
+# Constructor
+
+function PANOCIterator(x0::T; fs=Zero(), As=Identity(blocksize(x0)), fq=Zero(), Aq=Identity(blocksize(x0)), g=Zero(), gamma::R=-1.0, maxit::I=10000, tol::R=1e-4, adaptive=false, memory=10, verbose=1, verbose_freq=100, alpha=0.95, sigma=0.5) where {I, R, T}
+    n = blocksize(x0)
+    mq = size(Aq, 1)
+    ms = size(As, 1)
+    x = blockcopy(x0)
+    y = blockzeros(x0)
+    xbar = blockzeros(x0)
+    FPR_x = blockzeros(x0)
+    Aqx = blockzeros(mq)
+    Asx = blockzeros(ms)
+    gradfq_Aqx = blockzeros(mq)
+    gradfs_Asx = blockzeros(ms)
+    At_gradf_Ax = blockzeros(n)
+    d = blockzeros(x0)
+    PANOCIterator{I, R, T}(x, fs, As, fq, Aq, g, gamma, maxit, tol, adaptive, verbose, verbose_freq, alpha, sigma, 0.0, y, xbar, LBFGS(x, memory), FPR_x, Aqx, Asx, gradfq_Aqx, gradfs_Asx, 0.0, 0.0, 0.0, At_gradf_Ax, 0.0, 0.0, [], [], d)
+end
+
+################################################################################
+# Utility methods
+
+maxit(sol::PANOCIterator) = sol.maxit
+
+converged(sol::PANOCIterator, it) = blockmaxabs(sol.FPR_x)/sol.gamma <= sol.tol
+
+verbose(sol::PANOCIterator) = sol.verbose > 0 
+verbose(sol::PANOCIterator, it) = sol.verbose > 0 && (sol.verbose == 2 ? true : (it == 1 || it%sol.verbose_freq == 0))
+
+function display(sol::PANOCIterator)
+	@printf("%6s | %10s | %10s | %10s | %10s |\n ", "it", "gamma", "fpr", "tau", "FBE")
+	@printf("------|------------|------------|------------|------------|\n")
+end
+function display(sol::PANOCIterator, it)
+    @printf("%6d | %7.4e | %7.4e | %7.4e | %7.4e | \n", it, sol.gamma, blockmaxabs(sol.FPR_x)/sol.gamma, sol.tau, sol.FBE_x)
+end
+
+function Base.show(io::IO, sol::PANOCIterator)
+	println(io, "PANOC" )
+	println(io, "fpr        : $(blockmaxabs(sol.FPR_x))")
+	println(io, "gamma      : $(sol.gamma)")
+	println(io, "tau        : $(sol.tau)")
+	print(  io, "FBE        : $(sol.FBE_x)")
+end
+
+################################################################################
+# Initialization
+
+function initialize(sol::PANOCIterator)
+
+    # compute first forward-backward step here
+    A_mul_B!(sol.Aqx, sol.Aq, sol.x)
+    sol.fq_Aqx = gradient!(sol.gradfq_Aqx, sol.fq, sol.Aqx)
+    A_mul_B!(sol.Asx, sol.As, sol.x)
+    sol.fs_Asx = gradient!(sol.gradfs_Asx, sol.fs, sol.Asx)
+    blockaxpy!(sol.At_gradf_Ax, sol.As'*sol.gradfs_Asx, 1.0, sol.Aq'*sol.gradfq_Aqx)
+    sol.f_Ax = sol.fs_Asx + sol.fq_Aqx
+
+    if sol.gamma <= 0.0 # estimate L in this case, and set gamma = 1/L
+        # this part should be as follows:
+        # 1) if adaptive = false and only fq is present then L is "accurate"
+        # 2) otherwise L is "inaccurate" and set adaptive = true
+        # TODO: implement case 1), now 2) is always performed
+        xeps = sol.x .+ sqrt(eps())
+        Aqxeps = sol.Aq*xeps
+        gradfq_Aqxeps, = gradient(sol.fq, Aqxeps)
+        Asxeps = sol.As*xeps
+        gradfs_Asxeps, = gradient(sol.fs, Asxeps)
+        At_gradf_Axeps = sol.As'*gradfs_Asxeps .+ sol.Aq'*gradfq_Aqxeps
+        L = blockvecnorm(sol.At_gradf_Ax .- At_gradf_Axeps)/(sqrt(eps()*blocklength(xeps)))
+        sol.adaptive = true
+        # in both cases set gamma = 1/L
+        sol.gamma = sol.alpha/L
+    end
+
+    blockaxpy!(sol.y, sol.x, -sol.gamma, sol.At_gradf_Ax)
+    sol.g_xbar = prox!(sol.xbar, sol.g, sol.y, sol.gamma)
+    blockaxpy!(sol.FPR_x, sol.x, -1.0, sol.xbar)
+
+end
+
+################################################################################
+# Iteration
+
+function iterate(sol::PANOCIterator{I, R, T}, it) where {I, R, T}
+
+    # These need to be performed anyway (to compute xbarbar later on)
+    Aqxbar = sol.Aq*sol.xbar
+    gradfq_Aqxbar, fq_Aqxbar = gradient(sol.fq, Aqxbar)
+    Asxbar = sol.As*sol.xbar
+    gradfs_Asxbar, fs_Asxbar = gradient(sol.fs, Asxbar)
+    f_Axbar = fs_Asxbar + fq_Aqxbar
+
+    if sol.adaptive
+        for it_gam = 1:100 # TODO: replace/complement with lower bound on gamma
+            normFPR_x = blockvecnorm(sol.FPR_x)
+            uppbnd = sol.f_Ax - blockvecdot(sol.At_gradf_Ax, sol.FPR_x) + 0.5/sol.gamma*normFPR_x^2
+            if f_Axbar > uppbnd + 1e-6*abs(sol.f_Ax)
+                sol.gamma = 0.5*sol.gamma
+                blockaxpy!(sol.y, sol.x, -sol.gamma, sol.At_gradf_Ax)
+                sol.xbar, sol.g_xbar = prox(sol.g, sol.y, sol.gamma)
+                blockaxpy!(sol.FPR_x, sol.x, -1.0, sol.xbar)
+            else
+                break
+            end
+            Aqxbar = sol.Aq*sol.xbar
+            gradfq_Aqxbar, fq_Aqxbar = gradient(sol.fq, Aqxbar)
+            Asxbar = sol.As*sol.xbar
+            gradfs_Asxbar, fs_Asxbar = gradient(sol.fs, Asxbar)
+            f_Axbar = fs_Asxbar + fq_Aqxbar
+        end
+    end
+
+    # Compute value of FBE at x
+
+    normFPR_x = blockvecnorm(sol.FPR_x)
+    FBE_x = sol.f_Ax - blockvecdot(sol.At_gradf_Ax, sol.FPR_x) + 0.5/sol.gamma*normFPR_x^2 + sol.g_xbar
+
+    # Compute search direction
+
+    At_gradf_Axbar = sol.As'*gradfs_Asxbar .+ sol.Aq'*gradfq_Aqxbar
+    ybar = sol.xbar .- sol.gamma .* At_gradf_Axbar
+    xbarbar, g_xbarbar = prox(sol.g, ybar, sol.gamma)
+    FPR_xbar = sol.xbar .- xbarbar
+
+    if it > 1
+        update!(sol.H, sol.xbar, sol.xbar_prev, FPR_xbar, sol.FPR_xbar_prev)
+    end
+    A_mul_B!(sol.d, sol.H, 0.0 .- FPR_xbar) # TODO: not nice
+
+    Asd = sol.As * sol.d 
+    Aqd = sol.Aq * sol.d
+
+    # tau = 1
+    xnew = sol.xbar .+  sol.d
+    Asxnew = Asxbar .+  Asd
+    Aqxnew = Aqxbar .+  Aqd
+    gradfs_Asxnew, fs_Asxnew = gradient(sol.fs, Asxnew)
+    # TODO: can precompute most of next line before the iteration
+    gradfq_Aqxnew, fq_Aqxnew = gradient(sol.fq, Aqxnew)
+    f_Axnew = fs_Asxnew + fq_Aqxnew
+    At_gradf_Axnew = sol.As'*gradfs_Asxnew .+ sol.Aq'*gradfq_Aqxnew
+    ynew = xnew .- sol.gamma .* At_gradf_Axnew
+    xnewbar, g_xnewbar = prox(sol.g, ynew, sol.gamma)
+    FPR_xnew = xnew .- xnewbar
+    normFPR_xnew = blockvecnorm(FPR_xnew)
+    FBE_xnew = f_Axnew - blockvecdot(At_gradf_Axnew, FPR_xnew) + 0.5/sol.gamma*normFPR_xnew^2 + g_xnewbar
+
+    # Perform line-search over the FBE
+    tau = 1.0
+    maxit_tau = 9
+    C = sol.sigma*sol.gamma*(1.0-sol.alpha)
+    normFPR_xbar = blockvecnorm(FPR_xbar)
+    if FBE_xnew > FBE_x - (C/2)*normFPR_x^2 
+            Asdpg = sol.As * sol.FPR_x 
+            Aqdpg = sol.Aq * sol.FPR_x
+            for it_tau = 1:maxit_tau # TODO: replace/complement with lower bound on tau
+        	    tau = 0.5*tau
+        	    xnew = sol.xbar .+  tau .* sol.d .- (1-tau) .* sol.FPR_x
+        	    Asxnew = Asxbar .+  tau .* Asd   .- (1-tau) .* Asdpg
+        	    Aqxnew = Aqxbar .+  tau .* Aqd   .- (1-tau) .* Aqdpg
+        	    gradfs_Asxnew, fs_Asxnew = gradient(sol.fs, Asxnew)
+        	    # TODO: can precompute most of next line before the iteration
+        	    gradfq_Aqxnew, fq_Aqxnew = gradient(sol.fq, Aqxnew)
+        	    f_Axnew = fs_Asxnew + fq_Aqxnew
+        	    At_gradf_Axnew = sol.As'*gradfs_Asxnew .+ sol.Aq'*gradfq_Aqxnew
+        	    ynew = xnew .- sol.gamma .* At_gradf_Axnew
+        	    xnewbar, g_xnewbar = prox(sol.g, ynew, sol.gamma)
+        	    FPR_xnew = xnew .- xnewbar
+        	    normFPR_xnew = blockvecnorm(FPR_xnew)
+        	    FBE_xnew = f_Axnew - blockvecdot(At_gradf_Axnew, FPR_xnew) + 
+        	               0.5/sol.gamma*normFPR_xnew^2 + g_xnewbar
+
+        	if FBE_xnew <= FBE_x - (C/2)*normFPR_x^2 
+        	    break
+        	end
+
+            end
+    end
+            
+    sol.tau = tau
+    sol.FBE_x = FBE_xnew
+    sol.x = xnew
+    sol.f_Ax = f_Axnew
+    sol.At_gradf_Ax = At_gradf_Axnew 
+    sol.g_xbar = g_xnewbar
+    sol.FPR_x = FPR_xnew
+    sol.xbar_prev = sol.xbar
+    sol.FPR_xbar_prev = FPR_xbar
+    sol.xbar = xnewbar
+
+    return sol.xbar
+
+end
+
+################################################################################
+# Solver interface(s)
+
+function PANOC(x0; kwargs...)
+    sol = PANOCIterator(x0; kwargs...)
+    (it, point) = run(sol)
+    return (it, point, sol)
+end

--- a/src/algorithms/PANOC.jl
+++ b/src/algorithms/PANOC.jl
@@ -31,9 +31,11 @@ mutable struct PANOCIterator{I <: Integer, R <: Real, T <: BlockArray} <: Proxim
     At_gradf_Ax
     g_xbar
     FBE_x
-    xbar_prev
-    FPR_xbar_prev
+    FBE_x_prev
+    x_prev
+    FPR_x_prev
     d
+    normFPR_x
 end
 
 ################################################################################
@@ -44,16 +46,18 @@ function PANOCIterator(x0::T; fs=Zero(), As=Identity(blocksize(x0)), fq=Zero(), 
     mq = size(Aq, 1)
     ms = size(As, 1)
     x = blockcopy(x0)
+    x_prev = blockcopy(x0)
     y = blockzeros(x0)
     xbar = blockzeros(x0)
     FPR_x = blockzeros(x0)
+    FPR_x_prev = blockzeros(x0)
     Aqx = blockzeros(mq)
     Asx = blockzeros(ms)
     gradfq_Aqx = blockzeros(mq)
     gradfs_Asx = blockzeros(ms)
     At_gradf_Ax = blockzeros(n)
     d = blockzeros(x0)
-    PANOCIterator{I, R, T}(x, fs, As, fq, Aq, g, gamma, maxit, tol, adaptive, verbose, verbose_freq, alpha, sigma, 0.0, y, xbar, LBFGS(x, memory), FPR_x, Aqx, Asx, gradfq_Aqx, gradfs_Asx, 0.0, 0.0, 0.0, At_gradf_Ax, 0.0, 0.0, [], [], d)
+    PANOCIterator{I, R, T}(x, fs, As, fq, Aq, g, gamma, maxit, tol, adaptive, verbose, verbose_freq, alpha, sigma, 0.0, y, xbar, LBFGS(x, memory), FPR_x, Aqx, Asx, gradfq_Aqx, gradfs_Asx, 0.0, 0.0, 0.0, At_gradf_Ax, 0.0, 0.0, 0.0, x_prev, FPR_x_prev, d, 0)
 end
 
 ################################################################################
@@ -116,6 +120,36 @@ function initialize!(sol::PANOCIterator)
     sol.g_xbar = prox!(sol.xbar, sol.g, sol.y, sol.gamma)
     blockaxpy!(sol.FPR_x, sol.x, -1.0, sol.xbar)
 
+    normFPR_x = blockvecnorm(sol.FPR_x)
+    sol.FBE_x = sol.f_Ax - blockvecdot(sol.At_gradf_Ax, sol.FPR_x) + 0.5/sol.gamma*normFPR_x^2 + sol.g_xbar
+
+
+    if sol.adaptive
+	    Aqxbar = sol.Aq*sol.xbar
+	    gradfq_Aqxbar, fq_Aqxbar = gradient(sol.fq, Aqxbar)
+	    Asxbar = sol.As*sol.xbar
+	    gradfs_Asxbar, fs_Asxbar = gradient(sol.fs, Asxbar)
+	    f_Axbar = fs_Asxbar + fq_Aqxbar
+	    for it_gam = 1:100 # TODO: replace/complement with lower bound on gamma
+		    normFPR_x = blockvecnorm(sol.FPR_x)
+		    uppbnd = sol.f_Ax - blockvecdot(sol.At_gradf_Ax, sol.FPR_x) + 0.5/sol.gamma*normFPR_x^2
+		    if f_Axbar > uppbnd + 1e-6*abs(sol.f_Ax)
+			    sol.gamma = 0.5*sol.gamma
+			    blockaxpy!(sol.y, sol.x, -sol.gamma, sol.At_gradf_Ax)
+			    sol.xbar, sol.g_xbar = prox(sol.g, sol.y, sol.gamma)
+			    blockaxpy!(sol.FPR_x, sol.x, -1.0, sol.xbar)
+		    else
+			    break
+		    end
+            
+		    Aqxbar = sol.Aq*sol.xbar
+		    gradfq_Aqxbar, fq_Aqxbar = gradient(sol.fq, Aqxbar)
+		    Asxbar = sol.As*sol.xbar
+		    gradfs_Asxbar, fs_Asxbar = gradient(sol.fs, Asxbar)
+		    f_Axbar = fs_Asxbar + fq_Aqxbar
+	    end
+    end
+
 end
 
 ################################################################################
@@ -123,112 +157,86 @@ end
 
 function iterate!(sol::PANOCIterator{I, R, T}, it::I) where {I, R, T}
 
-    # These need to be performed anyway (to compute xbarbar later on)
-    Aqxbar = sol.Aq*sol.xbar
-    gradfq_Aqxbar, fq_Aqxbar = gradient(sol.fq, Aqxbar)
-    Asxbar = sol.As*sol.xbar
-    gradfs_Asxbar, fs_Asxbar = gradient(sol.fs, Asxbar)
-    f_Axbar = fs_Asxbar + fq_Aqxbar
+	xbar = sol.xbar
+	x = sol.x
 
-    if sol.adaptive
-        for it_gam = 1:100 # TODO: replace/complement with lower bound on gamma
-            normFPR_x = blockvecnorm(sol.FPR_x)
-            uppbnd = sol.f_Ax - blockvecdot(sol.At_gradf_Ax, sol.FPR_x) + 0.5/sol.gamma*normFPR_x^2
-            if f_Axbar > uppbnd + 1e-6*abs(sol.f_Ax)
-                sol.gamma = 0.5*sol.gamma
-                blockaxpy!(sol.y, sol.x, -sol.gamma, sol.At_gradf_Ax)
-                sol.xbar, sol.g_xbar = prox(sol.g, sol.y, sol.gamma)
-                blockaxpy!(sol.FPR_x, sol.x, -1.0, sol.xbar)
-            else
-                break
-            end
-            Aqxbar = sol.Aq*sol.xbar
-            gradfq_Aqxbar, fq_Aqxbar = gradient(sol.fq, Aqxbar)
-            Asxbar = sol.As*sol.xbar
-            gradfs_Asxbar, fs_Asxbar = gradient(sol.fs, Asxbar)
-            f_Axbar = fs_Asxbar + fq_Aqxbar
-        end
-    end
+	if it > 1
+		update!(sol.H, sol.x, sol.x_prev, sol.FPR_x, sol.FPR_x_prev)
+	end
+	A_mul_B!(sol.d, sol.H, 0.0 .- sol.FPR_x) # TODO: not nice
 
-    # Compute value of FBE at x
+	sol.FPR_x_prev, sol.FPR_x = sol.FPR_x, sol.FPR_x_prev
+	blockset!(sol.x_prev, sol.x)
 
-    normFPR_x = blockvecnorm(sol.FPR_x)
-    FBE_x = sol.f_Ax - blockvecdot(sol.At_gradf_Ax, sol.FPR_x) + 0.5/sol.gamma*normFPR_x^2 + sol.g_xbar
+	FBE_x = sol.FBE_x
+	normFPR_x = sol.normFPR_x
+	C = sol.sigma*sol.gamma*(1.0-sol.alpha)
+	maxit_tau = 10
+	tau = 1.0
+    
+	for it_tau = 1:maxit_tau # TODO: replace/complement with lower bound on tau
 
-    # Compute search direction
+		xnew = (1-tau).*xbar .+ tau .* (x.+sol.d)
+	   
+		# calculate new FBE in xnew
 
-    At_gradf_Axbar = sol.As'*gradfs_Asxbar .+ sol.Aq'*gradfq_Aqxbar
-    ybar = sol.xbar .- sol.gamma .* At_gradf_Axbar
-    xbarbar, g_xbarbar = prox(sol.g, ybar, sol.gamma)
-    FPR_xbar = sol.xbar .- xbarbar
+		A_mul_B!(sol.Aqx, sol.Aq, xnew)
+		sol.fq_Aqx = gradient!(sol.gradfq_Aqx, sol.fq, sol.Aqx)
+		A_mul_B!(sol.Asx, sol.As, xnew)
+		sol.fs_Asx = gradient!(sol.gradfs_Asx, sol.fs, sol.Asx)
+		blockaxpy!(sol.At_gradf_Ax, sol.As'*sol.gradfs_Asx, 1.0, sol.Aq'*sol.gradfq_Aqx)
+		sol.f_Ax = sol.fs_Asx + sol.fq_Aqx
 
-    if it > 1
-        update!(sol.H, sol.xbar, sol.xbar_prev, FPR_xbar, sol.FPR_xbar_prev)
-    end
-    A_mul_B!(sol.d, sol.H, 0.0 .- FPR_xbar) # TODO: not nice
+		# gradient step
+		blockaxpy!(sol.y, xnew, -sol.gamma, sol.At_gradf_Ax)
+		# prox step
+		xnewbar, g_xnewbar = prox(sol.g, sol.y, sol.gamma)
+	    
+		FPR_xnew = xnew .- xnewbar
+		norm_FPRxnew = blockvecnorm(FPR_xnew)
+	    
+		FBE_xnew = sol.f_Ax - blockvecdot(sol.At_gradf_Ax, FPR_xnew) + 
+		           0.5/sol.gamma*norm_FPRxnew^2 + g_xnewbar
 
-    Asd = sol.As * sol.d 
-    Aqd = sol.Aq * sol.d
+		if FBE_xnew <= FBE_x - (C/2)*normFPR_x^2 || it_tau == maxit_tau
+			sol.normFPR_x = norm_FPRxnew
+			sol.FPR_x = FPR_xnew
+			sol.FBE_x = FBE_xnew
+			sol.x, sol.xbar = xnew, xnewbar
+			sol.tau = tau
+			break
+		end
+		tau *= 0.5
+    
+	end
 
-    # tau = 1
-    xnew = sol.xbar .+  sol.d
-    Asxnew = Asxbar .+  Asd
-    Aqxnew = Aqxbar .+  Aqd
-    gradfs_Asxnew, fs_Asxnew = gradient(sol.fs, Asxnew)
-    # TODO: can precompute most of next line before the iteration
-    gradfq_Aqxnew, fq_Aqxnew = gradient(sol.fq, Aqxnew)
-    f_Axnew = fs_Asxnew + fq_Aqxnew
-    At_gradf_Axnew = sol.As'*gradfs_Asxnew .+ sol.Aq'*gradfq_Aqxnew
-    ynew = xnew .- sol.gamma .* At_gradf_Axnew
-    xnewbar, g_xnewbar = prox(sol.g, ynew, sol.gamma)
-    FPR_xnew = xnew .- xnewbar
-    normFPR_xnew = blockvecnorm(FPR_xnew)
-    FBE_xnew = f_Axnew - blockvecdot(At_gradf_Axnew, FPR_xnew) + 0.5/sol.gamma*normFPR_xnew^2 + g_xnewbar
+	if sol.adaptive
+		Aqxbar = sol.Aq*sol.xbar
+		gradfq_Aqxbar, fq_Aqxbar = gradient(sol.fq, Aqxbar)
+		Asxbar = sol.As*sol.xbar
+		gradfs_Asxbar, fs_Asxbar = gradient(sol.fs, Asxbar)
+		f_Axbar = fs_Asxbar + fq_Aqxbar
+		for it_gam = 1:100 # TODO: replace/complement with lower bound on gamma
+		    normFPR_x = blockvecnorm(sol.FPR_x)
+		    uppbnd = sol.f_Ax - blockvecdot(sol.At_gradf_Ax, sol.FPR_x) + 0.5/sol.gamma*normFPR_x^2
+		    if f_Axbar > uppbnd + 1e-6*abs(sol.f_Ax)
+			    sol.gamma = 0.5*sol.gamma
+			    blockaxpy!(sol.y, sol.x, -sol.gamma, sol.At_gradf_Ax)
+			    sol.xbar, sol.g_xbar = prox(sol.g, sol.y, sol.gamma)
+			    blockaxpy!(sol.FPR_x, sol.x, -1.0, sol.xbar)
+		    else
+			    break
+		    end
+		
+		    Aqxbar = sol.Aq*sol.xbar
+		    gradfq_Aqxbar, fq_Aqxbar = gradient(sol.fq, Aqxbar)
+		    Asxbar = sol.As*sol.xbar
+		    gradfs_Asxbar, fs_Asxbar = gradient(sol.fs, Asxbar)
+		    f_Axbar = fs_Asxbar + fq_Aqxbar
+		end
+	end
 
-    # Perform line-search over the FBE
-    tau = 1.0
-    maxit_tau = 9
-    C = sol.sigma*sol.gamma*(1.0-sol.alpha)
-    normFPR_xbar = blockvecnorm(FPR_xbar)
-    if FBE_xnew > FBE_x - (C/2)*normFPR_x^2 
-            Asdpg = sol.As * sol.FPR_x 
-            Aqdpg = sol.Aq * sol.FPR_x
-            for it_tau = 1:maxit_tau # TODO: replace/complement with lower bound on tau
-        	    tau = 0.5*tau
-        	    xnew = sol.xbar .+  tau .* sol.d .- (1-tau) .* sol.FPR_x
-        	    Asxnew = Asxbar .+  tau .* Asd   .- (1-tau) .* Asdpg
-        	    Aqxnew = Aqxbar .+  tau .* Aqd   .- (1-tau) .* Aqdpg
-        	    gradfs_Asxnew, fs_Asxnew = gradient(sol.fs, Asxnew)
-        	    # TODO: can precompute most of next line before the iteration
-        	    gradfq_Aqxnew, fq_Aqxnew = gradient(sol.fq, Aqxnew)
-        	    f_Axnew = fs_Asxnew + fq_Aqxnew
-        	    At_gradf_Axnew = sol.As'*gradfs_Asxnew .+ sol.Aq'*gradfq_Aqxnew
-        	    ynew = xnew .- sol.gamma .* At_gradf_Axnew
-        	    xnewbar, g_xnewbar = prox(sol.g, ynew, sol.gamma)
-        	    FPR_xnew = xnew .- xnewbar
-        	    normFPR_xnew = blockvecnorm(FPR_xnew)
-        	    FBE_xnew = f_Axnew - blockvecdot(At_gradf_Axnew, FPR_xnew) + 
-        	               0.5/sol.gamma*normFPR_xnew^2 + g_xnewbar
-
-        	if FBE_xnew <= FBE_x - (C/2)*normFPR_x^2 
-        	    break
-        	end
-
-            end
-    end
-            
-    sol.tau = tau
-    sol.FBE_x = FBE_xnew
-    sol.x = xnew
-    sol.f_Ax = f_Axnew
-    sol.At_gradf_Ax = At_gradf_Axnew 
-    sol.g_xbar = g_xnewbar
-    sol.FPR_x = FPR_xnew
-    sol.xbar_prev = sol.xbar
-    sol.FPR_xbar_prev = FPR_xbar
-    sol.xbar = xnewbar
-
-    return sol.xbar 
+	return sol.xbar 
 
 end
 

--- a/src/algorithms/PANOC.jl
+++ b/src/algorithms/PANOC.jl
@@ -1,7 +1,7 @@
 ################################################################################
 # PANOC iterator (with L-BFGS directions)
 
-mutable struct PANOCIterator{I <: Integer, R <: Real, T <: BlockArray} <: ProximalAlgorithm{I}
+mutable struct PANOCIterator{I <: Integer, R <: Real, T <: BlockArray} <: ProximalAlgorithm{I,T}
     x::T
     fs
     As
@@ -61,7 +61,7 @@ end
 
 maxit(sol::PANOCIterator) = sol.maxit
 
-converged(sol::PANOCIterator, it) = blockmaxabs(sol.FPR_x)/sol.gamma <= sol.tol
+converged(sol::PANOCIterator, it) = it > 0 && blockmaxabs(sol.FPR_x)/sol.gamma <= sol.tol
 
 verbose(sol::PANOCIterator) = sol.verbose > 0 
 verbose(sol::PANOCIterator, it) = sol.verbose > 0 && (sol.verbose == 2 ? true : (it == 1 || it%sol.verbose_freq == 0))
@@ -228,7 +228,7 @@ function iterate!(sol::PANOCIterator{I, R, T}, it::I) where {I, R, T}
     sol.FPR_xbar_prev = FPR_xbar
     sol.xbar = xnewbar
 
-    return 
+    return sol.xbar 
 
 end
 
@@ -241,6 +241,6 @@ function PANOC(x0; kwargs...)
 end
 
 function PANOC!(sol::PANOCIterator)
-    it = run!(sol)
-    return (it, sol.xbar, sol)
+    it, point = run!(sol)
+    return (it, point, sol)
 end

--- a/src/algorithms/PANOC.jl
+++ b/src/algorithms/PANOC.jl
@@ -23,17 +23,32 @@ mutable struct PANOCIterator{I <: Integer, R <: Real, T <: BlockArray} <: Proxim
     FPR_x
     Aqx
     Asx
+    Aqxnew
+    Asxnew
+    Aqd
+    Asd
+    Aqfb
+    Asfb
     gradfq_Aqx
     gradfs_Asx
+    Aqxbar
+    Asxbar
+    gradfq_Aqxbar
+    gradfs_Asxbar
     fs_Asx
     fq_Aqx
     f_Ax
     At_gradf_Ax
+    Aqt_gradfq_Aqx
+    Ast_gradfs_Asx
     g_xbar
     FBE_x
     FBE_x_prev
     x_prev
     FPR_x_prev
+    xnew
+    xnewbar
+    FPR_xnew
     d
     normFPR_x
 end
@@ -45,19 +60,49 @@ function PANOCIterator(x0::T; fs=Zero(), As=Identity(blocksize(x0)), fq=Zero(), 
     n = blocksize(x0)
     mq = size(Aq, 1)
     ms = size(As, 1)
-    x = blockcopy(x0)
-    x_prev = blockcopy(x0)
+    x       = x0
+    xbar    = blockzeros(x0)
+    x_prev  = blockcopy(x0)
+    xnew    = blockcopy(x0)
+    xnewbar = blockcopy(x0)
     y = blockzeros(x0)
-    xbar = blockzeros(x0)
     FPR_x = blockzeros(x0)
     FPR_x_prev = blockzeros(x0)
+    FPR_xnew = blockzeros(x0)
     Aqx = blockzeros(mq)
     Asx = blockzeros(ms)
+    Aqxnew = blockzeros(mq)
+    Asxnew = blockzeros(ms)
+    Aqd = blockzeros(mq)
+    Asd = blockzeros(ms)
+    Aqfb = blockzeros(mq)
+    Asfb = blockzeros(ms)
     gradfq_Aqx = blockzeros(mq)
     gradfs_Asx = blockzeros(ms)
+    Aqxbar = blockzeros(mq)
+    Asxbar = blockzeros(ms)
+    gradfq_Aqxbar = blockzeros(mq)
+    gradfs_Asxbar = blockzeros(ms)
     At_gradf_Ax = blockzeros(n)
+    Aqt_gradfq_Aqx = blockzeros(n)
+    Ast_gradfs_Asx = blockzeros(n)
     d = blockzeros(x0)
-    PANOCIterator{I, R, T}(x, fs, As, fq, Aq, g, gamma, maxit, tol, adaptive, verbose, verbose_freq, alpha, sigma, 0.0, y, xbar, LBFGS(x, memory), FPR_x, Aqx, Asx, gradfq_Aqx, gradfs_Asx, 0.0, 0.0, 0.0, At_gradf_Ax, 0.0, 0.0, 0.0, x_prev, FPR_x_prev, d, 0)
+    PANOCIterator{I, R, T}(
+			   x, fs, As, 
+			   fq, Aq, g, 
+			   gamma, maxit, tol, 
+			   adaptive, verbose, 
+			   verbose_freq, alpha, sigma, 
+			   0.0, y, xbar, 
+			   LBFGS(x, memory), FPR_x, 
+			   Aqx, Asx, Aqxnew, Asxnew, Aqd, Asd, Aqfb, Asfb, gradfq_Aqx, gradfs_Asx, 
+			   Aqxbar, Asxbar, gradfq_Aqxbar, gradfs_Asxbar, 
+			   0.0, 0.0, 0.0, 
+			   At_gradf_Ax, Aqt_gradfq_Aqx, Ast_gradfs_Asx,
+			   0.0, 0.0, 
+			   0.0, x_prev, FPR_x_prev, 
+			   xnew, xnewbar, FPR_xnew,
+			   d, 0)
 end
 
 ################################################################################
@@ -65,7 +110,17 @@ end
 
 maxit(sol::PANOCIterator) = sol.maxit
 
-converged(sol::PANOCIterator, it) = it > 0 && blockmaxabs(sol.FPR_x)/sol.gamma <= sol.tol
+function converged(sol::PANOCIterator, it) 
+	cnv = it > 0 && blockmaxabs(sol.FPR_x)/sol.gamma <= sol.tol
+	if cnv
+		if isodd(it)
+			# make sure x0 is x to warm start correctly
+			sol.x, sol.xnew = sol.xnew, sol.x 
+		end
+		blockset!(sol.x,sol.xbar)
+	end
+	return cnv
+end
 
 verbose(sol::PANOCIterator) = sol.verbose > 0 
 verbose(sol::PANOCIterator, it) = sol.verbose > 0 && (sol.verbose == 2 ? true : (it == 1 || it%sol.verbose_freq == 0))
@@ -90,6 +145,11 @@ end
 # Initialization
 
 function initialize!(sol::PANOCIterator)
+
+    # reset L-BFGS operator (would be nice to have this option)
+    # TODO add function reset!(::LBFGS) in AbstractOperators
+    sol.H.currmem, sol.H.curridx = 0, 0
+    sol.H.H = 1.0
 
     # compute first forward-backward step here
     A_mul_B!(sol.Aqx, sol.Aq, sol.x)
@@ -134,10 +194,10 @@ function iterate!(sol::PANOCIterator{I, R, T}, it::I) where {I, R, T}
 
 	if sol.adaptive
 		for it_gam = 1:100 # TODO: replace/complement with lower bound on gamma
-			Aqxbar = sol.Aq*sol.xbar
-			gradfq_Aqxbar, fq_Aqxbar = gradient(sol.fq, Aqxbar)
-			Asxbar = sol.As*sol.xbar
-			gradfs_Asxbar, fs_Asxbar = gradient(sol.fs, Asxbar)
+			A_mul_B!(sol.Aqxbar, sol.Aq, sol.xbar)
+			fq_Aqxbar = gradient!(sol.gradfq_Aqxbar, sol.fq, sol.Aqxbar)
+			A_mul_B!(sol.Asxbar, sol.As, sol.xbar)
+			fs_Asxbar = gradient!(sol.gradfs_Asxbar, sol.fs, sol.Asxbar)
 			f_Axbar = fs_Asxbar + fq_Aqxbar
 
 			uppbnd = sol.f_Ax - blockvecdot(sol.At_gradf_Ax, sol.FPR_x) + 
@@ -165,44 +225,101 @@ function iterate!(sol::PANOCIterator{I, R, T}, it::I) where {I, R, T}
 
 	C = sol.sigma*sol.gamma*(1.0-sol.alpha)
 	maxit_tau = 10
-	tau = 1.0
-    
-	for it_tau = 1:maxit_tau # TODO: replace/complement with lower bound on tau
 
-		xnew = (1-tau).*sol.xbar .+ tau .* (sol.x.+sol.d)
-	   
-		# calculate new FBE in xnew
+	# tau = 1
+	sol.tau = one(R)
 
-		A_mul_B!(sol.Aqx, sol.Aq, xnew)
-		sol.fq_Aqx = gradient!(sol.gradfq_Aqx, sol.fq, sol.Aqx)
-		A_mul_B!(sol.Asx, sol.As, xnew)
-		sol.fs_Asx = gradient!(sol.gradfs_Asx, sol.fs, sol.Asx)
-		blockaxpy!(sol.At_gradf_Ax, sol.As'*sol.gradfs_Asx, 1.0, sol.Aq'*sol.gradfq_Aqx)
-		sol.f_Ax = sol.fs_Asx + sol.fq_Aqx
+	A_mul_B!( sol.Aqd, sol.Aq, sol.d)
+	A_mul_B!( sol.Asd, sol.As, sol.d)
 
-		# gradient step
-		blockaxpy!(sol.y, xnew, -sol.gamma, sol.At_gradf_Ax)
-		# prox step
-		xnewbar, g_xnewbar = prox(sol.g, sol.y, sol.gamma)
-	    
-		FPR_xnew = xnew .- xnewbar
-		norm_FPRxnew = blockvecnorm(FPR_xnew)
-	    
-		FBE_xnew = sol.f_Ax - blockvecdot(sol.At_gradf_Ax, FPR_xnew) + 
-		           0.5/sol.gamma*norm_FPRxnew^2 + g_xnewbar
+	# xnew = x + tau*d
+	blockaxpy!(sol.xnew, sol.x, sol.tau, sol.d) 
+	# Aq*xnew = Aq*x + tau*Aq*d
+	blockaxpy!(sol.Aqxnew, sol.Aqx, sol.tau, sol.Aqd) 
+	# As*xnew = As*x + tau*As*d
+	blockaxpy!(sol.Asxnew, sol.Asx, sol.tau, sol.Asd) 
 
-		if FBE_xnew <= sol.FBE_x - (C/2)*sol.normFPR_x^2 || it_tau == maxit_tau
-			sol.normFPR_x = norm_FPRxnew
-			sol.FPR_x = FPR_xnew
-			sol.FBE_x = FBE_xnew
-			sol.x, sol.xbar = xnew, xnewbar
-			sol.tau = tau
-			sol.g_xbar = g_xnewbar
-			break
+	# calculate new FBE in xnew
+	sol.fq_Aqx = gradient!(sol.gradfq_Aqx, sol.fq, sol.Aqxnew)
+	sol.fs_Asx = gradient!(sol.gradfs_Asx, sol.fs, sol.Asxnew)
+
+	Ac_mul_B!(sol.Aqt_gradfq_Aqx, sol.Aq, sol.gradfq_Aqx)
+	Ac_mul_B!(sol.Ast_gradfs_Asx, sol.As, sol.gradfs_Asx)
+
+	blockaxpy!(sol.At_gradf_Ax, sol.Aqt_gradfq_Aqx, 1.0, sol.Ast_gradfs_Asx)
+	sol.f_Ax = sol.fs_Asx + sol.fq_Aqx
+
+	# gradient step
+	blockaxpy!(sol.y, sol.xnew, -sol.gamma, sol.At_gradf_Ax)
+	# prox step
+	sol.g_xbar = prox!(sol.xnewbar, sol.g, sol.y, sol.gamma)
+	
+	blockaxpy!(sol.FPR_xnew, sol.xnew, -1.0, sol.xnewbar)
+	norm_FPRxnew = blockvecnorm(sol.FPR_xnew)
+	
+	FBE_xnew = sol.f_Ax - blockvecdot(sol.At_gradf_Ax, sol.FPR_xnew) + 
+		           0.5/sol.gamma*norm_FPRxnew^2 + sol.g_xbar
+
+
+	A_mul_B!(sol.Aqfb, sol.Aq, sol.FPR_x_prev)
+	A_mul_B!(sol.Asfb, sol.As, sol.FPR_x_prev)
+		
+	if FBE_xnew > sol.FBE_x - (C/2)*sol.normFPR_x^2 
+		# start using convex combination of FB direction and d 
+
+		for it_tau = 1:maxit_tau # TODO: replace/complement with lower bound on tau
+
+			# xnew = x + tau*d
+			blockaxpy!(sol.xnew, sol.x, sol.tau, sol.d) 
+			# xnew += x + (1-tau*d)*fb
+			blockaxpy!(sol.xnew, sol.xnew, sol.tau-1.0, sol.FPR_x_prev) 
+
+			# Aq*xnew = Aq*x + tau*Aq*d
+			blockaxpy!(sol.Aqxnew, sol.Aqx, sol.tau, sol.Aqd) 
+			# Aq*xnew += Aq*x + (1-tau*d)*Aq*d_fb
+			blockaxpy!(sol.Aqxnew, sol.Aqxnew, sol.tau-1.0, sol.Aqfb) 
+
+			# As*xnew = As*x + tau*As*d
+			blockaxpy!(sol.Asxnew, sol.Asx, sol.tau, sol.Asd) 
+			# Aq*xnew += Aq*x + (1-tau*d)*Aq*d_fb
+			blockaxpy!(sol.Asxnew, sol.Asxnew, sol.tau-1.0, sol.Asfb) 
+			
+			# calculate new FBE in xnew
+			sol.fq_Aqx = gradient!(sol.gradfq_Aqx, sol.fq, sol.Aqxnew)
+			sol.fs_Asx = gradient!(sol.gradfs_Asx, sol.fs, sol.Asxnew)
+
+			Ac_mul_B!(sol.Aqt_gradfq_Aqx, sol.Aq, sol.gradfq_Aqx)
+			Ac_mul_B!(sol.Ast_gradfs_Asx, sol.As, sol.gradfs_Asx)
+
+			blockaxpy!(sol.At_gradf_Ax, sol.Aqt_gradfq_Aqx, 1.0, sol.Ast_gradfs_Asx)
+			sol.f_Ax = sol.fs_Asx + sol.fq_Aqx
+
+			# gradient step
+			blockaxpy!(sol.y, sol.xnew, -sol.gamma, sol.At_gradf_Ax)
+			# prox step
+			sol.g_xbar = prox!(sol.xnewbar, sol.g, sol.y, sol.gamma)
+		    
+			blockaxpy!(sol.FPR_xnew, sol.xnew, -1.0, sol.xnewbar)
+			norm_FPRxnew = blockvecnorm(sol.FPR_xnew)
+		    
+			FBE_xnew = sol.f_Ax - blockvecdot(sol.At_gradf_Ax, sol.FPR_xnew) + 
+				   0.5/sol.gamma*norm_FPRxnew^2 + sol.g_xbar
+
+			if FBE_xnew <= sol.FBE_x - (C/2)*sol.normFPR_x^2 
+				break
+			end
+			sol.tau *= 0.5
+
 		end
-		tau *= 0.5
-    
+
 	end
+
+	sol.normFPR_x = norm_FPRxnew
+	sol.FPR_x, sol.FPR_xnew = sol.FPR_xnew, sol.FPR_x
+	sol.FBE_x = FBE_xnew
+	sol.x, sol.xbar, sol.xnew, sol.xnewbar = sol.xnew, sol.xnewbar, sol.x, sol.xbar
+	sol.Aqx, sol.Aqxnew = sol.Aqxnew, sol.Aqx
+	sol.Asx, sol.Asxnew = sol.Asxnew, sol.Asx
 
 	return sol.xbar 
 
@@ -214,5 +331,6 @@ end
 function PANOC(x0; kwargs...)
     sol = PANOCIterator(x0; kwargs...)
     it, point = run!(sol)
+    blockset!(x0, point)
     return (it, point, sol)
 end

--- a/src/algorithms/ZeroFPR.jl
+++ b/src/algorithms/ZeroFPR.jl
@@ -216,10 +216,6 @@ end
 
 function ZeroFPR(x0; kwargs...)
     sol = ZeroFPRIterator(x0; kwargs...)
-    return ZeroFPR!(sol)
-end
-
-function ZeroFPR!(sol::ZeroFPRIterator)
     it, point = run!(sol)
     return (it, point, sol)
 end

--- a/src/algorithms/ZeroFPR.jl
+++ b/src/algorithms/ZeroFPR.jl
@@ -1,7 +1,7 @@
 ################################################################################
 # ZeroFPR iterator (with L-BFGS directions)
 
-mutable struct ZeroFPRIterator{I <: Integer, R <: Real, T <: BlockArray} <: ProximalAlgorithm{I}
+mutable struct ZeroFPRIterator{I <: Integer, R <: Real, T <: BlockArray} <: ProximalAlgorithm{I,T}
     x::T
     fs
     As
@@ -61,7 +61,7 @@ end
 
 maxit(sol::ZeroFPRIterator) = sol.maxit
 
-converged(sol::ZeroFPRIterator, it) = blockmaxabs(sol.FPR_x)/sol.gamma <= sol.tol
+converged(sol::ZeroFPRIterator, it) = it > 0 && blockmaxabs(sol.FPR_x)/sol.gamma <= sol.tol
 
 verbose(sol::ZeroFPRIterator) = sol.verbose > 0 
 verbose(sol::ZeroFPRIterator, it) = sol.verbose > 0 && (sol.verbose == 2 ? true : (it == 1 || it%sol.verbose_freq == 0))
@@ -207,7 +207,7 @@ function iterate!(sol::ZeroFPRIterator{I, R, T}, it::I) where {I, R, T}
         tau = 0.5*tau
     end
 
-    return 
+    return sol.xbar 
 
 end
 
@@ -220,6 +220,6 @@ function ZeroFPR(x0; kwargs...)
 end
 
 function ZeroFPR!(sol::ZeroFPRIterator)
-    it = run!(sol)
-    return (it, sol.xbar, sol)
+    it, point = run!(sol)
+    return (it, point, sol)
 end

--- a/src/algorithms/ZeroFPR.jl
+++ b/src/algorithms/ZeroFPR.jl
@@ -1,7 +1,7 @@
 ################################################################################
 # ZeroFPR iterator (with L-BFGS directions)
 
-mutable struct ZeroFPRIterator{I <: Integer, R <: Real, T <: BlockArray} <: ProximalAlgorithm{I, T}
+mutable struct ZeroFPRIterator{I <: Integer, R <: Real, T <: BlockArray} <: ProximalAlgorithm{I}
     x::T
     fs
     As
@@ -85,7 +85,7 @@ end
 ################################################################################
 # Initialization
 
-function initialize(sol::ZeroFPRIterator)
+function initialize!(sol::ZeroFPRIterator)
 
     # compute first forward-backward step here
     A_mul_B!(sol.Aqx, sol.Aq, sol.x)
@@ -121,7 +121,7 @@ end
 ################################################################################
 # Iteration
 
-function iterate(sol::ZeroFPRIterator{I, R, T}, it) where {I, R, T}
+function iterate!(sol::ZeroFPRIterator{I, R, T}, it::I) where {I, R, T}
 
     # These need to be performed anyway (to compute xbarbar later on)
     Aqxbar = sol.Aq*sol.xbar
@@ -207,7 +207,7 @@ function iterate(sol::ZeroFPRIterator{I, R, T}, it) where {I, R, T}
         tau = 0.5*tau
     end
 
-    return sol.xbar
+    return 
 
 end
 
@@ -216,6 +216,10 @@ end
 
 function ZeroFPR(x0; kwargs...)
     sol = ZeroFPRIterator(x0; kwargs...)
-    (it, point) = run(sol)
-    return (it, point, sol)
+    return ZeroFPR!(sol)
+end
+
+function ZeroFPR!(sol::ZeroFPRIterator)
+    it = run!(sol)
+    return (it, sol.xbar, sol)
 end

--- a/src/algorithms/ZeroFPR.jl
+++ b/src/algorithms/ZeroFPR.jl
@@ -176,7 +176,8 @@ function iterate(sol::ZeroFPRIterator{I, R, T}, it) where {I, R, T}
 
     C = sol.sigma*sol.gamma*(1.0-sol.alpha)
 
-    for it_tau = 1:32 # TODO: replace/complement with lower bound on tau
+    maxit_tau = 10
+    for it_tau = 1:maxit_tau # TODO: replace/complement with lower bound on tau
         xnew = sol.xbar .+ tau .* sol.d
         Asxnew = Asxbar .+ tau .* Asd
         Aqxnew = Aqxbar .+ tau .* Aqd
@@ -190,7 +191,7 @@ function iterate(sol::ZeroFPRIterator{I, R, T}, it) where {I, R, T}
         FPR_xnew = xnew .- xnewbar
         normFPR_xnew = blockvecnorm(FPR_xnew)
         FBE_xnew = f_Axnew - blockvecdot(At_gradf_Axnew, FPR_xnew) + 0.5/sol.gamma*normFPR_xnew^2 + g_xnewbar
-        if FBE_xnew <= FBE_x - (C/2)*normFPR_x^2
+        if FBE_xnew <= FBE_x - (C/2)*normFPR_x^2 || it_tau == maxit_tau
             sol.tau = tau
             sol.FBE_x = FBE_xnew
             sol.x = xnew

--- a/src/algorithms/ZeroFPR.jl
+++ b/src/algorithms/ZeroFPR.jl
@@ -171,12 +171,12 @@ function iterate(sol::ZeroFPRIterator{I, R, T}, it) where {I, R, T}
 
     tau = 1.0
 
-    Asd = sol.As * sol.d
+    Asd = sol.As * sol.d 
     Aqd = sol.Aq * sol.d
 
     C = sol.sigma*sol.gamma*(1.0-sol.alpha)
 
-    for it_tau = 1:10 # TODO: replace/complement with lower bound on tau
+    for it_tau = 1:32 # TODO: replace/complement with lower bound on tau
         xnew = sol.xbar .+ tau .* sol.d
         Asxnew = Asxbar .+ tau .* Asd
         Aqxnew = Aqxbar .+ tau .* Aqd
@@ -194,6 +194,9 @@ function iterate(sol::ZeroFPRIterator{I, R, T}, it) where {I, R, T}
             sol.tau = tau
             sol.FBE_x = FBE_xnew
             sol.x = xnew
+	    sol.f_Ax = f_Axnew
+	    sol.At_gradf_Ax = At_gradf_Axnew 
+	    sol.g_xbar = g_xnewbar
             sol.FPR_x = FPR_xnew
             sol.xbar_prev = sol.xbar
             sol.FPR_xbar_prev = FPR_xbar

--- a/src/algorithms/ZeroFPR.jl
+++ b/src/algorithms/ZeroFPR.jl
@@ -54,7 +54,7 @@ function ZeroFPRIterator(x0::T; fs=Zero(), As=Identity(blocksize(x0)), fq=Zero()
     n = blocksize(x0)
     mq = size(Aq, 1)
     ms = size(As, 1)
-    x = x0
+    x = blockcopy(x0)
     y = blockzeros(x0)
     xbar = blockzeros(x0)
     xbarbar = blockzeros(x0)
@@ -102,17 +102,7 @@ end
 
 maxit(sol::ZeroFPRIterator) = sol.maxit
 
-function converged(sol::ZeroFPRIterator, it) 
-	cnv = it > 0 && blockmaxabs(sol.FPR_x)/sol.gamma <= sol.tol
-	if cnv
-		if isodd(it)
-			# make sure x0 is x to warm start correctly
-			sol.x, sol.xnew = sol.xnew, sol.x 
-		end
-		blockset!(sol.x,sol.xbar)
-	end
-	return cnv
-end
+converged(sol::ZeroFPRIterator, it) = it > 0 && blockmaxabs(sol.FPR_x)/sol.gamma <= sol.tol
 
 verbose(sol::ZeroFPRIterator) = sol.verbose > 0 
 verbose(sol::ZeroFPRIterator, it) = sol.verbose > 0 && (sol.verbose == 2 ? true : (it == 1 || it%sol.verbose_freq == 0))

--- a/src/algorithms/ZeroFPR.jl
+++ b/src/algorithms/ZeroFPR.jl
@@ -19,19 +19,30 @@ mutable struct ZeroFPRIterator{I <: Integer, R <: Real, T <: BlockArray} <: Prox
     tau::R
     y # gradient step
     xbar # proximal-gradient step
+    xbarbar # proximal-gradient step
+    xnew 
+    xnewbar 
     H # inverse Jacobian approximation
     FPR_x
     Aqx
     Asx
+    Aqxbar
+    Asxbar
+    Aqxnew
+    Asxnew
+    Aqd
+    Asd
     gradfq_Aqx
     gradfs_Asx
     fs_Asx
     fq_Aqx
     f_Ax
     At_gradf_Ax
+    Ast_gradfs_Asx
+    Aqt_gradfq_Aqx
     g_xbar
     FBE_x
-    xbar_prev
+    FPR_xbar
     FPR_xbar_prev
     d
 end
@@ -43,17 +54,47 @@ function ZeroFPRIterator(x0::T; fs=Zero(), As=Identity(blocksize(x0)), fq=Zero()
     n = blocksize(x0)
     mq = size(Aq, 1)
     ms = size(As, 1)
-    x = blockcopy(x0)
+    x = x0
     y = blockzeros(x0)
     xbar = blockzeros(x0)
+    xbarbar = blockzeros(x0)
+    xnew = blockzeros(x0)
+    xnewbar = blockzeros(x0)
+    xbar = blockzeros(x0)
     FPR_x = blockzeros(x0)
+    FPR_xbar_prev = blockzeros(x0)
+    FPR_xbar = blockzeros(x0)
     Aqx = blockzeros(mq)
     Asx = blockzeros(ms)
+    Aqxbar = blockzeros(mq)
+    Asxbar = blockzeros(ms)
+    Aqxnew = blockzeros(mq)
+    Asxnew = blockzeros(ms)
+    Aqd = blockzeros(mq)
+    Asd = blockzeros(ms)
     gradfq_Aqx = blockzeros(mq)
     gradfs_Asx = blockzeros(ms)
     At_gradf_Ax = blockzeros(n)
+    Ast_gradfs_Asx = blockzeros(n)
+    Aqt_gradfq_Aqx = blockzeros(n)
     d = blockzeros(x0)
-    ZeroFPRIterator{I, R, T}(x, fs, As, fq, Aq, g, gamma, maxit, tol, adaptive, verbose, verbose_freq, alpha, sigma, 0.0, y, xbar, LBFGS(x, memory), FPR_x, Aqx, Asx, gradfq_Aqx, gradfs_Asx, 0.0, 0.0, 0.0, At_gradf_Ax, 0.0, 0.0, [], [], d)
+    H = LBFGS(x, memory)
+    ZeroFPRIterator{I, R, T}(x, 
+			     fs, As, 
+			     fq, Aq, g, 
+			     gamma, maxit, tol, adaptive, verbose, verbose_freq, 
+			     alpha, sigma, 0.0, y, 
+			     xbar, xbarbar, xnew, xnewbar, 
+			     H, FPR_x, 
+			     Aqx, Asx, 
+			     Aqxbar, Asxbar, 
+			     Aqxnew, Asxnew, 
+			     Aqd, Asd, 
+			     gradfq_Aqx, gradfs_Asx, 
+			     0.0, 0.0, 0.0, 
+			     At_gradf_Ax, Ast_gradfs_Asx, Aqt_gradfq_Aqx,
+			     0.0, 0.0, 
+			     FPR_xbar, FPR_xbar_prev, d)
 end
 
 ################################################################################
@@ -61,7 +102,17 @@ end
 
 maxit(sol::ZeroFPRIterator) = sol.maxit
 
-converged(sol::ZeroFPRIterator, it) = it > 0 && blockmaxabs(sol.FPR_x)/sol.gamma <= sol.tol
+function converged(sol::ZeroFPRIterator, it) 
+	cnv = it > 0 && blockmaxabs(sol.FPR_x)/sol.gamma <= sol.tol
+	if cnv
+		if isodd(it)
+			# make sure x0 is x to warm start correctly
+			sol.x, sol.xnew = sol.xnew, sol.x 
+		end
+		blockset!(sol.x,sol.xbar)
+	end
+	return cnv
+end
 
 verbose(sol::ZeroFPRIterator) = sol.verbose > 0 
 verbose(sol::ZeroFPRIterator, it) = sol.verbose > 0 && (sol.verbose == 2 ? true : (it == 1 || it%sol.verbose_freq == 0))
@@ -86,6 +137,11 @@ end
 # Initialization
 
 function initialize!(sol::ZeroFPRIterator)
+
+    # reset L-BFGS operator (would be nice to have this option)
+    # TODO add function reset!(::LBFGS) in AbstractOperators
+    sol.H.currmem, sol.H.curridx = 0, 0
+    sol.H.H = 1.0
 
     # compute first forward-backward step here
     A_mul_B!(sol.Aqx, sol.Aq, sol.x)
@@ -124,10 +180,10 @@ end
 function iterate!(sol::ZeroFPRIterator{I, R, T}, it::I) where {I, R, T}
 
     # These need to be performed anyway (to compute xbarbar later on)
-    Aqxbar = sol.Aq*sol.xbar
-    gradfq_Aqxbar, fq_Aqxbar = gradient(sol.fq, Aqxbar)
-    Asxbar = sol.As*sol.xbar
-    gradfs_Asxbar, fs_Asxbar = gradient(sol.fs, Asxbar)
+    A_mul_B!(sol.Aqxbar, sol.Aq, sol.xbar)
+    fq_Aqxbar = gradient!(sol.gradfq_Aqx, sol.fq, sol.Aqxbar)
+    A_mul_B!(sol.Asxbar, sol.As, sol.xbar)
+    fs_Asxbar = gradient!(sol.gradfs_Asx, sol.fs, sol.Asxbar)
     f_Axbar = fs_Asxbar + fq_Aqxbar
 
     if sol.adaptive
@@ -142,11 +198,11 @@ function iterate!(sol::ZeroFPRIterator{I, R, T}, it::I) where {I, R, T}
             else
                 break
             end
-            Aqxbar = sol.Aq*sol.xbar
-            gradfq_Aqxbar, fq_Aqxbar = gradient(sol.fq, Aqxbar)
-            Asxbar = sol.As*sol.xbar
-            gradfs_Asxbar, fs_Asxbar = gradient(sol.fs, Asxbar)
-            f_Axbar = fs_Asxbar + fq_Aqxbar
+	    A_mul_B!(sol.Aqxbar, sol.Aq, sol.xbar)
+	    fq_Aqxbar = gradient!(sol.gradfq_Aqx, sol.fq, sol.Aqxbar)
+	    A_mul_B!(sol.Asxbar, sol.As, sol.xbar)
+	    fs_Asxbar = gradient!(sol.gradfs_Asx, sol.fs, sol.Asxbar)
+	    f_Axbar = fs_Asxbar + fq_Aqxbar
         end
     end
 
@@ -156,56 +212,60 @@ function iterate!(sol::ZeroFPRIterator{I, R, T}, it::I) where {I, R, T}
     FBE_x = sol.f_Ax - blockvecdot(sol.At_gradf_Ax, sol.FPR_x) + 0.5/sol.gamma*normFPR_x^2 + sol.g_xbar
 
     # Compute search direction
-
-    At_gradf_Axbar = sol.As'*gradfs_Asxbar .+ sol.Aq'*gradfq_Aqxbar
-    ybar = sol.xbar .- sol.gamma .* At_gradf_Axbar
-    xbarbar, g_xbarbar = prox(sol.g, ybar, sol.gamma)
-    FPR_xbar = sol.xbar .- xbarbar
+    Ac_mul_B!(sol.Ast_gradfs_Asx, sol.As, sol.gradfs_Asx)
+    Ac_mul_B!(sol.Aqt_gradfq_Aqx, sol.Aq, sol.gradfq_Aqx)
+    blockaxpy!(sol.At_gradf_Ax, sol.Ast_gradfs_Asx, 1.0, sol.Aqt_gradfq_Aqx)
+    blockaxpy!(sol.y, sol.xbar, -sol.gamma, sol.At_gradf_Ax)
+    g_xbarbar = prox!(sol.xbarbar, sol.g, sol.y, sol.gamma)
+    blockaxpy!(sol.FPR_xbar, sol.xbar, -1.0, sol.xbarbar)
 
     if it > 1
-        update!(sol.H, sol.xbar, sol.xbar_prev, FPR_xbar, sol.FPR_xbar_prev)
+        update!(sol.H, sol.xbar, sol.xnewbar, sol.FPR_xbar, sol.FPR_xbar_prev)
     end
-    A_mul_B!(sol.d, sol.H, 0.0 .- FPR_xbar) # TODO: not nice
+    A_mul_B!(sol.d, sol.H, 0.0 .- sol.FPR_xbar) # TODO: not nice
 
     # Perform line-search over the FBE
 
-    tau = 1.0
+    sol.tau = 1.0
 
-    Asd = sol.As * sol.d 
-    Aqd = sol.Aq * sol.d
+    A_mul_B!(sol.Asd, sol.As, sol.d)
+    A_mul_B!(sol.Aqd, sol.Aq, sol.d)
 
     C = sol.sigma*sol.gamma*(1.0-sol.alpha)
 
+    g_xnewbar = zero(R)
+    f_Axnew = zero(R)
+    FBE_xnew = zero(R)
+
     maxit_tau = 10
     for it_tau = 1:maxit_tau # TODO: replace/complement with lower bound on tau
-        xnew = sol.xbar .+ tau .* sol.d
-        Asxnew = Asxbar .+ tau .* Asd
-        Aqxnew = Aqxbar .+ tau .* Aqd
-        gradfs_Asxnew, fs_Asxnew = gradient(sol.fs, Asxnew)
+	blockaxpy!(sol.xnew, sol.xbar, sol.tau, sol.d)
+	blockaxpy!(sol.Asxnew, sol.Asxbar, sol.tau, sol.Asd)
+	blockaxpy!(sol.Aqxnew, sol.Aqxbar, sol.tau, sol.Aqd)
+        fs_Asxnew = gradient!(sol.gradfs_Asx, sol.fs, sol.Asxnew)
         # TODO: can precompute most of next line before the iteration
-        gradfq_Aqxnew, fq_Aqxnew = gradient(sol.fq, Aqxnew)
+        fq_Aqxnew = gradient!(sol.gradfq_Aqx, sol.fq, sol.Aqxnew)
         f_Axnew = fs_Asxnew + fq_Aqxnew
-        At_gradf_Axnew = sol.As'*gradfs_Asxnew .+ sol.Aq'*gradfq_Aqxnew
-        ynew = xnew .- sol.gamma .* At_gradf_Axnew
-        xnewbar, g_xnewbar = prox(sol.g, ynew, sol.gamma)
-        FPR_xnew = xnew .- xnewbar
-        normFPR_xnew = blockvecnorm(FPR_xnew)
-        FBE_xnew = f_Axnew - blockvecdot(At_gradf_Axnew, FPR_xnew) + 0.5/sol.gamma*normFPR_xnew^2 + g_xnewbar
-        if FBE_xnew <= FBE_x - (C/2)*normFPR_x^2 || it_tau == maxit_tau
-            sol.tau = tau
-            sol.FBE_x = FBE_xnew
-            sol.x = xnew
-	    sol.f_Ax = f_Axnew
-	    sol.At_gradf_Ax = At_gradf_Axnew 
-	    sol.g_xbar = g_xnewbar
-            sol.FPR_x = FPR_xnew
-            sol.xbar_prev = sol.xbar
-            sol.FPR_xbar_prev = FPR_xbar
-            sol.xbar = xnewbar
+	Ac_mul_B!(sol.Ast_gradfs_Asx, sol.As, sol.gradfs_Asx)
+	Ac_mul_B!(sol.Aqt_gradfq_Aqx, sol.Aq, sol.gradfq_Aqx)
+	blockaxpy!(sol.At_gradf_Ax, sol.Ast_gradfs_Asx, 1.0, sol.Aqt_gradfq_Aqx)
+	blockaxpy!(sol.y, sol.xnew, -sol.gamma, sol.At_gradf_Ax)
+        g_xnewbar = prox!(sol.xnewbar, sol.g, sol.y, sol.gamma)
+	blockaxpy!(sol.FPR_x, sol.xnew, -1.0, sol.xnewbar)
+        normFPR_xnew = blockvecnorm(sol.FPR_x)
+        FBE_xnew = f_Axnew - blockvecdot(sol.At_gradf_Ax, sol.FPR_x) + 0.5/sol.gamma*normFPR_xnew^2 + g_xnewbar
+        if FBE_xnew <= FBE_x - (C/2)*normFPR_x^2
             break
         end
-        tau = 0.5*tau
+        sol.tau = 0.5*sol.tau
     end
+
+    sol.FBE_x = FBE_xnew
+    sol.x, sol.xnew = sol.xnew, sol.x
+    sol.f_Ax = f_Axnew
+    sol.g_xbar = g_xnewbar
+    sol.FPR_xbar_prev, sol.FPR_xbar = sol.FPR_xbar, sol.FPR_xbar_prev
+    sol.xbar, sol.xnewbar = sol.xnewbar, sol.xbar #xnewbar becames xbar_prev
 
     return sol.xbar 
 

--- a/src/template/Template.jl
+++ b/src/template/Template.jl
@@ -1,7 +1,7 @@
 ################################################################################
 # Template iterator
 
-struct TemplateIterator{I <: Integer, T <: BlockArray} <: ProximalAlgorithm{I, T}
+struct TemplateIterator{I <: Integer, T <: BlockArray} <: ProximalAlgorithm{I}
     x::T
     maxit::I
     # Put here problem description, other parameters, method memory,
@@ -33,7 +33,7 @@ end
 ################################################################################
 # Initialization
 
-function initialize(sol::TemplateIterator)
+function initialize!(sol::TemplateIterator)
     # One shouldn't really be printing anything here
     println("Initializing the iterations")
 end
@@ -41,7 +41,7 @@ end
 ################################################################################
 # Iteration
 
-function iterate(sol::TemplateIterator{I, T}, it::I) where {I, T}
+function iterate!(sol::TemplateIterator{I, T}, it::I) where {I, T}
     # One shouldn't really be printing anything here
     println("Performing one iteration")
     return sol.x
@@ -53,7 +53,12 @@ end
 function Template(x0; kwargs...)
     # Create iterable
     sol = TemplateIterator(x0; kwargs...)
+    return Template!(sol)
+end
+
+# in-place interface
+function Template!(sol::TemplateIterator)
     # Run iterations
-    (it, point) = run(sol)
-    return (it, point, sol)
+    it = run!(sol)
+    return (it, sol.x, sol)
 end

--- a/src/template/Template.jl
+++ b/src/template/Template.jl
@@ -53,12 +53,7 @@ end
 function Template(x0; kwargs...)
     # Create iterable
     sol = TemplateIterator(x0; kwargs...)
-    return Template!(sol)
-end
-
-# in-place interface
-function Template!(sol::TemplateIterator)
     # Run iterations
     it, point = run!(sol)
-    return (it, point, sol)
+    return it, point, sol 
 end

--- a/src/template/Template.jl
+++ b/src/template/Template.jl
@@ -1,7 +1,7 @@
 ################################################################################
 # Template iterator
 
-struct TemplateIterator{I <: Integer, T <: BlockArray} <: ProximalAlgorithm{I}
+struct TemplateIterator{I <: Integer, T <: BlockArray} <: ProximalAlgorithm{I,T}
     x::T
     maxit::I
     # Put here problem description, other parameters, method memory,
@@ -59,6 +59,6 @@ end
 # in-place interface
 function Template!(sol::TemplateIterator)
     # Run iterations
-    it = run!(sol)
-    return (it, sol.x, sol)
+    it, point = run!(sol)
+    return (it, point, sol)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -13,6 +13,7 @@ end
 @testset "Algorithms" begin
     include("test_template.jl")
     include("test_lasso_small.jl")
+    include("test_lasso_harder.jl")
     include("test_lasso_small_split_x.jl")
     include("test_lasso_small_split_f.jl")
     include("test_l1logreg_small.jl")

--- a/test/test_afba.jl
+++ b/test/test_afba.jl
@@ -63,6 +63,8 @@ println("      nnz(x)    = $(norm(sol.x, 2))")
 @test it ==itnum[1]
 println(sol)
 
+@time it, x, y, sol = ProximalAlgorithms.AFBA!(sol)
+
 # f=\equiv 0 (Chambolle-Pock)
 y0 = randn(m)
 @time it, x, y, sol = ProximalAlgorithms.AFBA(x0, y0; g=g, h=f, L=A, theta=theta, mu=mu)

--- a/test/test_afba.jl
+++ b/test/test_afba.jl
@@ -63,7 +63,7 @@ println("      nnz(x)    = $(norm(sol.x, 2))")
 @test it ==itnum[1]
 println(sol)
 
-@time it, x, y, sol = ProximalAlgorithms.AFBA!(sol)
+@time it, (x, y) = ProximalAlgorithms.run!(sol)
 
 # f=\equiv 0 (Chambolle-Pock)
 y0 = randn(m)

--- a/test/test_l1logreg_small.jl
+++ b/test/test_l1logreg_small.jl
@@ -19,7 +19,7 @@ x_star = [0, 0, 2.114635341704963e-01, 0, 2.845881348733116e+00]
 x0 = zeros(n)
 @time it, x, sol = ProximalAlgorithms.FBS(x0; fs=f, As=A, g=g, tol=1e-6, adaptive=true)
 @test vecnorm(x - x_star, Inf) <= 1e-4
-@test it == 1658
+#@test it == 1658
 println(sol)
 
 # Fast/Adaptive
@@ -27,7 +27,7 @@ println(sol)
 x0 = zeros(n)
 @time it, x, sol = ProximalAlgorithms.FBS(x0; fs=f, As=A, g=g, tol=1e-6, adaptive=true, fast=true)
 @test vecnorm(x - x_star, Inf) <= 1e-4
-@test it == 473
+#@test it == 473
 println(sol)
 
 # ZeroFPR/Adaptive
@@ -35,5 +35,5 @@ println(sol)
 x0 = zeros(n)
 @time it, x, sol = ProximalAlgorithms.ZeroFPR(x0; fs=f, As=A, g=g, tol=1e-6, adaptive=true)
 @test vecnorm(x - x_star, Inf) <= 1e-4
-@test it == 19
+#@test it == 19
 println(sol)

--- a/test/test_l1logreg_small.jl
+++ b/test/test_l1logreg_small.jl
@@ -19,7 +19,7 @@ x_star = [0, 0, 2.114635341704963e-01, 0, 2.845881348733116e+00]
 x0 = zeros(n)
 @time it, x, sol = ProximalAlgorithms.FBS(x0; fs=f, As=A, g=g, tol=1e-6, adaptive=true)
 @test vecnorm(x - x_star, Inf) <= 1e-4
-#@test it == 1658
+@test it < 1700
 println(sol)
 
 # Fast/Adaptive
@@ -27,7 +27,7 @@ println(sol)
 x0 = zeros(n)
 @time it, x, sol = ProximalAlgorithms.FBS(x0; fs=f, As=A, g=g, tol=1e-6, adaptive=true, fast=true)
 @test vecnorm(x - x_star, Inf) <= 1e-4
-#@test it == 473
+@test it < 500
 println(sol)
 
 # ZeroFPR/Adaptive
@@ -35,7 +35,7 @@ println(sol)
 x0 = zeros(n)
 @time it, x, sol = ProximalAlgorithms.ZeroFPR(x0; fs=f, As=A, g=g, tol=1e-6, adaptive=true)
 @test vecnorm(x - x_star, Inf) <= 1e-4
-#@test it == 19
+@test it < 25
 println(sol)
 
 # PANOC/Adaptive
@@ -43,5 +43,5 @@ println(sol)
 x0 = zeros(n)
 @time it, x, sol = ProximalAlgorithms.PANOC(x0; fs=f, As=A, g=g, tol=1e-6, adaptive=true)
 @test vecnorm(x - x_star, Inf) <= 1e-4
-#@test it == 19
+@test it < 35
 println(sol)

--- a/test/test_l1logreg_small.jl
+++ b/test/test_l1logreg_small.jl
@@ -37,3 +37,11 @@ x0 = zeros(n)
 @test vecnorm(x - x_star, Inf) <= 1e-4
 #@test it == 19
 println(sol)
+
+# PANOC/Adaptive
+
+x0 = zeros(n)
+@time it, x, sol = ProximalAlgorithms.PANOC(x0; fs=f, As=A, g=g, tol=1e-6, adaptive=true)
+@test vecnorm(x - x_star, Inf) <= 1e-4
+#@test it == 19
+println(sol)

--- a/test/test_lasso_harder.jl
+++ b/test/test_lasso_harder.jl
@@ -28,3 +28,9 @@ x0 = zeros(n)
 @test norm(xFBS-xZ) < 1e-8
 @test itZ < itFBS
 
+# PANOC/Nonadaptive
+x0 = zeros(n)
+@time itP, xP, sol = ProximalAlgorithms.PANOC(x0; fq=f, Aq=A, g=g, gamma=1.0/norm(A)^2, tol = 1e-8)
+
+@test norm(xP-xZ) < 1e-8
+@test itP < itFBS

--- a/test/test_lasso_harder.jl
+++ b/test/test_lasso_harder.jl
@@ -19,18 +19,19 @@ g = NormL1(lam)
 
 # fast FBS/Nonadaptive
 x0 = zeros(n)
-@time itFBS, xFBS, sol = ProximalAlgorithms.FBS(x0; fq=f, Aq=A, g=g, gamma=1.0/norm(A)^2, fast = true, tol = 1e-8)
+@time it, xFBS, sol = ProximalAlgorithms.FBS(x0; fq=f, Aq=A, g=g, gamma=1.0/norm(A)^2, fast = true, tol = 1e-8)
+@test it < 1800
 
 # ZeroFPR/Nonadaptive
 x0 = zeros(n)
-@time itZ, xZ, sol = ProximalAlgorithms.ZeroFPR(x0; fq=f, Aq=A, g=g, gamma=1.0/norm(A)^2, tol = 1e-8)
+@time it, xZ, sol = ProximalAlgorithms.ZeroFPR(x0; fq=f, Aq=A, g=g, gamma=1.0/norm(A)^2, tol = 1e-8)
 
 @test norm(xFBS-xZ) < 1e-8
-@test itZ < itFBS
+@test it < 150
 
 # PANOC/Nonadaptive
 x0 = zeros(n)
-@time itP, xP, sol = ProximalAlgorithms.PANOC(x0; fq=f, Aq=A, g=g, gamma=1.0/norm(A)^2, tol = 1e-8)
+@time it, xP, sol = ProximalAlgorithms.PANOC(x0; fq=f, Aq=A, g=g, gamma=1.0/norm(A)^2, tol = 1e-8)
 
 @test norm(xP-xZ) < 1e-8
-@test itP < itFBS
+@test it < 300

--- a/test/test_lasso_harder.jl
+++ b/test/test_lasso_harder.jl
@@ -1,0 +1,32 @@
+using ProximalOperators
+
+srand(123)
+m, n = 10,100
+
+A = randn(m,n)
+U,S,V = svd(A)
+#create ill conditioned matrix 
+S[floor(Int,0.5*min(m,n)):end] .= 0.
+A = U*diagm(S)*V'
+
+x_star = sprandn(n,0.5)
+b = A*x_star+20*randn(m)
+
+f = Translate(SqrNormL2(), -b)
+f2 = LeastSquares(A, b)
+lam = 1e-2*vecnorm(A'*b, Inf)
+g = NormL1(lam)
+
+# fast FBS/Nonadaptive
+
+println("\n FPG ProximalAlgorithms.jl \n")
+x0 = zeros(n)
+@time itFBS, xFBS, sol = ProximalAlgorithms.FBS(x0; fq=f, Aq=A, g=g, gamma=1.0/norm(A)^2, fast = true, tol = 1e-8)
+
+println("\n ZeroFPR ProximalAlgorithms.jl \n")
+x0 = zeros(n)
+@time itZ, xZ, sol = ProximalAlgorithms.ZeroFPR(x0; fq=f, Aq=A, g=g, gamma=1.0/norm(A)^2, tol = 1e-8)
+
+@test norm(xFBS-xZ) < 1e-8
+@test itZ < itFBS
+

--- a/test/test_lasso_harder.jl
+++ b/test/test_lasso_harder.jl
@@ -18,12 +18,10 @@ lam = 1e-2*vecnorm(A'*b, Inf)
 g = NormL1(lam)
 
 # fast FBS/Nonadaptive
-
-println("\n FPG ProximalAlgorithms.jl \n")
 x0 = zeros(n)
 @time itFBS, xFBS, sol = ProximalAlgorithms.FBS(x0; fq=f, Aq=A, g=g, gamma=1.0/norm(A)^2, fast = true, tol = 1e-8)
 
-println("\n ZeroFPR ProximalAlgorithms.jl \n")
+# ZeroFPR/Nonadaptive
 x0 = zeros(n)
 @time itZ, xZ, sol = ProximalAlgorithms.ZeroFPR(x0; fq=f, Aq=A, g=g, gamma=1.0/norm(A)^2, tol = 1e-8)
 

--- a/test/test_lasso_small.jl
+++ b/test/test_lasso_small.jl
@@ -20,7 +20,7 @@ x_star = [-3.877278911564627e-01, 0, 0, 2.174149659863943e-02, 6.168435374149660
 x0 = zeros(n)
 @time it, x, sol = ProximalAlgorithms.FBS(x0; fq=f, Aq=A, g=g, gamma=1.0/norm(A)^2)
 @test vecnorm(x - x_star, Inf) <= 1e-4
-@test it == 140
+#@test it == 140
 println(sol)
 
 # Nonfast/Adaptive
@@ -28,7 +28,7 @@ println(sol)
 x0 = zeros(n)
 @time it, x, sol = ProximalAlgorithms.FBS(x0; fq=f, Aq=A, g=g, adaptive=true)
 @test vecnorm(x - x_star, Inf) <= 1e-4
-@test it == 247
+#@test it == 247
 println(sol)
 
 # Fast/Nonadaptive
@@ -36,7 +36,7 @@ println(sol)
 x0 = zeros(n)
 @time it, x, sol = ProximalAlgorithms.FBS(x0; fq=f, Aq=A, g=g, gamma=1.0/norm(A)^2, fast=true)
 @test vecnorm(x - x_star, Inf) <= 1e-4
-@test it == 94
+#@test it == 94
 println(sol)
 
 # Fast/Adaptive
@@ -44,7 +44,7 @@ println(sol)
 x0 = zeros(n)
 @time it, x, sol = ProximalAlgorithms.FBS(x0; fq=f, Aq=A, g=g, adaptive=true, fast=true)
 @test vecnorm(x - x_star, Inf) <= 1e-4
-@test it == 156
+#@test it == 156
 println(sol)
 
 # ZeroFPR/Nonadaptive
@@ -52,7 +52,7 @@ println(sol)
 x0 = zeros(n)
 @time it, x, sol = ProximalAlgorithms.ZeroFPR(x0; fq=f, Aq=A, g=g, gamma=1.0/norm(A)^2)
 @test vecnorm(x - x_star, Inf) <= 1e-4
-@test it == 8
+#@test it == 8
 println(sol)
 
 # ZeroFPR/Adaptive
@@ -60,7 +60,7 @@ println(sol)
 x0 = zeros(n)
 @time it, x, sol = ProximalAlgorithms.ZeroFPR(x0; fq=f, Aq=A, g=g, adaptive=true)
 @test vecnorm(x - x_star, Inf) <= 1e-4
-@test it == 10
+#@test it == 10
 println(sol)
 
 # Douglas-Rachford

--- a/test/test_lasso_small.jl
+++ b/test/test_lasso_small.jl
@@ -23,19 +23,9 @@ x0 = zeros(n)
 @test it < 150
 println(sol)
 
-@test object_id(x0) == object_id(sol.x)
-
-# test warm start
-x0 .= 0.0
-@time itws, xws = ProximalAlgorithms.run!(sol)
-@test vecnorm(xws - x_star, Inf) <= 1e-4
-@test itws == it
-
 # testing solver already at solution
 @time it, x = ProximalAlgorithms.run!(sol)
 @test it == 1
-
-@test object_id(x0) == object_id(sol.x)
 
 # Nonfast/Adaptive
 
@@ -53,19 +43,9 @@ x0 = zeros(n)
 @test it < 100
 println(sol)
 
-@test object_id(x0) == object_id(sol.x)
-
-# test warm start
-x0 .= 0.0
-@time itws, xws = ProximalAlgorithms.run!(sol)
-@test vecnorm(xws - x_star, Inf) <= 1e-4
-@test itws == it
-
 # testing solver already at solution
 @time it, x = ProximalAlgorithms.run!(sol)
 @test it == 1
-
-@test object_id(x0) == object_id(sol.x)
 
 # Fast/Adaptive
 
@@ -82,14 +62,6 @@ x0 = zeros(n)
 @test vecnorm(x - x_star, Inf) <= 1e-4
 @test it < 15
 println(sol)
-
-@test object_id(x0) == object_id(sol.x)
-
-# test warm start
-x0 .= 0.0
-@time itws, xws = ProximalAlgorithms.run!(sol)
-@test vecnorm(xws - x_star, Inf) <= 1e-4
-@test itws == it
 
 #testing solver already at solution
 @time it, x = ProximalAlgorithms.run!(sol)
@@ -110,19 +82,9 @@ x0 = zeros(n)
 @test it < 20
 println(sol)
 
-@test object_id(x0) == object_id(sol.x)
-
-# test warm start
-x0 .= 0.0
-@time itws, xws = ProximalAlgorithms.run!(sol)
-@test vecnorm(xws - x_star, Inf) <= 1e-4
-@test itws == it
-
 # testing solver already at solution
 @time it, x = ProximalAlgorithms.run!(sol)
 @test it == 1
-
-@test object_id(x0) == object_id(sol.x)
 
 ## PANOC/Adaptive
 

--- a/test/test_lasso_small.jl
+++ b/test/test_lasso_small.jl
@@ -20,15 +20,15 @@ x_star = [-3.877278911564627e-01, 0, 0, 2.174149659863943e-02, 6.168435374149660
 x0 = zeros(n)
 @time it, x, sol = ProximalAlgorithms.FBS(x0; fq=f, Aq=A, g=g, gamma=1.0/norm(A)^2)
 @test vecnorm(x - x_star, Inf) <= 1e-4
-#@test it == 140
 println(sol)
+
+@time it, x, sol = ProximalAlgorithms.FBS!(sol)
 
 # Nonfast/Adaptive
 
 x0 = zeros(n)
 @time it, x, sol = ProximalAlgorithms.FBS(x0; fq=f, Aq=A, g=g, adaptive=true)
 @test vecnorm(x - x_star, Inf) <= 1e-4
-#@test it == 247
 println(sol)
 
 # Fast/Nonadaptive
@@ -36,7 +36,6 @@ println(sol)
 x0 = zeros(n)
 @time it, x, sol = ProximalAlgorithms.FBS(x0; fq=f, Aq=A, g=g, gamma=1.0/norm(A)^2, fast=true)
 @test vecnorm(x - x_star, Inf) <= 1e-4
-#@test it == 94
 println(sol)
 
 # Fast/Adaptive
@@ -44,7 +43,6 @@ println(sol)
 x0 = zeros(n)
 @time it, x, sol = ProximalAlgorithms.FBS(x0; fq=f, Aq=A, g=g, adaptive=true, fast=true)
 @test vecnorm(x - x_star, Inf) <= 1e-4
-#@test it == 156
 println(sol)
 
 # ZeroFPR/Nonadaptive
@@ -52,7 +50,6 @@ println(sol)
 x0 = zeros(n)
 @time it, x, sol = ProximalAlgorithms.ZeroFPR(x0; fq=f, Aq=A, g=g, gamma=1.0/norm(A)^2)
 @test vecnorm(x - x_star, Inf) <= 1e-4
-#@test it == 8
 println(sol)
 
 # ZeroFPR/Adaptive
@@ -60,14 +57,12 @@ println(sol)
 x0 = zeros(n)
 @time it, x, sol = ProximalAlgorithms.ZeroFPR(x0; fq=f, Aq=A, g=g, adaptive=true)
 @test vecnorm(x - x_star, Inf) <= 1e-4
-#@test it == 10
 
 # PANOC/Nonadaptive
 
 x0 = zeros(n)
 @time it, x, sol = ProximalAlgorithms.PANOC(x0; fq=f, Aq=A, g=g, gamma=1.0/norm(A)^2)
 @test vecnorm(x - x_star, Inf) <= 1e-4
-#@test it == 8
 println(sol)
 
 # PANOC/Adaptive
@@ -75,8 +70,6 @@ println(sol)
 x0 = zeros(n)
 @time it, x, sol = ProximalAlgorithms.PANOC(x0; fq=f, Aq=A, g=g, adaptive=true)
 @test vecnorm(x - x_star, Inf) <= 1e-4
-#@test it == 10
-
 println(sol)
 
 # Douglas-Rachford

--- a/test/test_lasso_small.jl
+++ b/test/test_lasso_small.jl
@@ -23,7 +23,7 @@ x0 = zeros(n)
 println(sol)
 
 #testing solver already at solution
-@time it, x, sol = ProximalAlgorithms.FBS!(sol)
+@time it, x = ProximalAlgorithms.run!(sol)
 
 # Nonfast/Adaptive
 
@@ -54,7 +54,7 @@ x0 = zeros(n)
 println(sol)
 
 #testing solver already at solution
-@time it, x, sol = ProximalAlgorithms.ZeroFPR!(sol)
+@time it, x = ProximalAlgorithms.run!(sol)
 
 # ZeroFPR/Adaptive
 
@@ -70,7 +70,7 @@ x0 = zeros(n)
 println(sol)
 
 #testing solver already at solution
-@time it, x, sol = ProximalAlgorithms.PANOC!(sol)
+@time it, x = ProximalAlgorithms.run!(sol)
 
 # PANOC/Adaptive
 
@@ -87,4 +87,4 @@ x0 = zeros(n)
 println(sol)
 
 #testing solver already at solution
-@time it, x, sol = ProximalAlgorithms.DRS!(sol)
+@time it, x = ProximalAlgorithms.run!(sol)

--- a/test/test_lasso_small.jl
+++ b/test/test_lasso_small.jl
@@ -20,16 +20,29 @@ x_star = [-3.877278911564627e-01, 0, 0, 2.174149659863943e-02, 6.168435374149660
 x0 = zeros(n)
 @time it, x, sol = ProximalAlgorithms.FBS(x0; fq=f, Aq=A, g=g, gamma=1.0/norm(A)^2)
 @test vecnorm(x - x_star, Inf) <= 1e-4
+@test it < 150
 println(sol)
 
-#testing solver already at solution
+@test object_id(x0) == object_id(sol.x)
+
+# test warm start
+x0 .= 0.0
+@time itws, xws = ProximalAlgorithms.run!(sol)
+@test vecnorm(xws - x_star, Inf) <= 1e-4
+@test itws == it
+
+# testing solver already at solution
 @time it, x = ProximalAlgorithms.run!(sol)
+@test it == 1
+
+@test object_id(x0) == object_id(sol.x)
 
 # Nonfast/Adaptive
 
 x0 = zeros(n)
 @time it, x, sol = ProximalAlgorithms.FBS(x0; fq=f, Aq=A, g=g, adaptive=true)
 @test vecnorm(x - x_star, Inf) <= 1e-4
+@test it < 300
 println(sol)
 
 # Fast/Nonadaptive
@@ -37,13 +50,29 @@ println(sol)
 x0 = zeros(n)
 @time it, x, sol = ProximalAlgorithms.FBS(x0; fq=f, Aq=A, g=g, gamma=1.0/norm(A)^2, fast=true)
 @test vecnorm(x - x_star, Inf) <= 1e-4
+@test it < 100
 println(sol)
+
+@test object_id(x0) == object_id(sol.x)
+
+# test warm start
+x0 .= 0.0
+@time itws, xws = ProximalAlgorithms.run!(sol)
+@test vecnorm(xws - x_star, Inf) <= 1e-4
+@test itws == it
+
+# testing solver already at solution
+@time it, x = ProximalAlgorithms.run!(sol)
+@test it == 1
+
+@test object_id(x0) == object_id(sol.x)
 
 # Fast/Adaptive
 
 x0 = zeros(n)
 @time it, x, sol = ProximalAlgorithms.FBS(x0; fq=f, Aq=A, g=g, adaptive=true, fast=true)
 @test vecnorm(x - x_star, Inf) <= 1e-4
+@test it < 200
 println(sol)
 
 # ZeroFPR/Nonadaptive
@@ -51,32 +80,56 @@ println(sol)
 x0 = zeros(n)
 @time it, x, sol = ProximalAlgorithms.ZeroFPR(x0; fq=f, Aq=A, g=g, gamma=1.0/norm(A)^2)
 @test vecnorm(x - x_star, Inf) <= 1e-4
+@test it < 15
 println(sol)
+
+@test object_id(x0) == object_id(sol.x)
+
+# test warm start
+x0 .= 0.0
+@time itws, xws = ProximalAlgorithms.run!(sol)
+@test vecnorm(xws - x_star, Inf) <= 1e-4
+@test itws == it
 
 #testing solver already at solution
 @time it, x = ProximalAlgorithms.run!(sol)
+@test it == 1
 
 # ZeroFPR/Adaptive
 
 x0 = zeros(n)
 @time it, x, sol = ProximalAlgorithms.ZeroFPR(x0; fq=f, Aq=A, g=g, adaptive=true)
 @test vecnorm(x - x_star, Inf) <= 1e-4
+@test it < 15
 
 # PANOC/Nonadaptive
 
 x0 = zeros(n)
 @time it, x, sol = ProximalAlgorithms.PANOC(x0; fq=f, Aq=A, g=g, gamma=1.0/norm(A)^2)
 @test vecnorm(x - x_star, Inf) <= 1e-4
+@test it < 20
 println(sol)
 
-#testing solver already at solution
+@test object_id(x0) == object_id(sol.x)
+
+# test warm start
+x0 .= 0.0
+@time itws, xws = ProximalAlgorithms.run!(sol)
+@test vecnorm(xws - x_star, Inf) <= 1e-4
+@test itws == it
+
+# testing solver already at solution
 @time it, x = ProximalAlgorithms.run!(sol)
+@test it == 1
+
+@test object_id(x0) == object_id(sol.x)
 
 ## PANOC/Adaptive
 
 x0 = zeros(n)
 @time it, x, sol = ProximalAlgorithms.PANOC(x0; fq=f, Aq=A, g=g, adaptive=true)
 @test vecnorm(x - x_star, Inf) <= 1e-4
+@test it < 20
 println(sol)
 
 # Douglas-Rachford
@@ -84,7 +137,9 @@ println(sol)
 x0 = zeros(n)
 @time it, x, sol = ProximalAlgorithms.DRS(x0; f=f2, g=g, gamma=10.0/norm(A)^2)
 @test vecnorm(x - x_star, Inf) <= 1e-4
+@test it < 30
 println(sol)
 
 #testing solver already at solution
 @time it, x = ProximalAlgorithms.run!(sol)
+@test it == 1

--- a/test/test_lasso_small.jl
+++ b/test/test_lasso_small.jl
@@ -22,6 +22,7 @@ x0 = zeros(n)
 @test vecnorm(x - x_star, Inf) <= 1e-4
 println(sol)
 
+#testing solver already at solution
 @time it, x, sol = ProximalAlgorithms.FBS!(sol)
 
 # Nonfast/Adaptive
@@ -52,6 +53,9 @@ x0 = zeros(n)
 @test vecnorm(x - x_star, Inf) <= 1e-4
 println(sol)
 
+#testing solver already at solution
+@time it, x, sol = ProximalAlgorithms.ZeroFPR!(sol)
+
 # ZeroFPR/Adaptive
 
 x0 = zeros(n)
@@ -64,6 +68,9 @@ x0 = zeros(n)
 @time it, x, sol = ProximalAlgorithms.PANOC(x0; fq=f, Aq=A, g=g, gamma=1.0/norm(A)^2)
 @test vecnorm(x - x_star, Inf) <= 1e-4
 println(sol)
+
+#testing solver already at solution
+@time it, x, sol = ProximalAlgorithms.PANOC!(sol)
 
 # PANOC/Adaptive
 
@@ -78,3 +85,6 @@ x0 = zeros(n)
 @time it, x, sol = ProximalAlgorithms.DRS(x0; f=f2, g=g, gamma=10.0/norm(A)^2)
 @test vecnorm(x - x_star, Inf) <= 1e-4
 println(sol)
+
+#testing solver already at solution
+@time it, x, sol = ProximalAlgorithms.DRS!(sol)

--- a/test/test_lasso_small.jl
+++ b/test/test_lasso_small.jl
@@ -63,6 +63,22 @@ x0 = zeros(n)
 #@test it == 10
 println(sol)
 
+# PANOC/Nonadaptive
+
+x0 = zeros(n)
+@time it, x, sol = ProximalAlgorithms.PANOC(x0; fq=f, Aq=A, g=g, gamma=1.0/norm(A)^2)
+@test vecnorm(x - x_star, Inf) <= 1e-4
+#@test it == 8
+println(sol)
+
+# PANOC/Adaptive
+
+x0 = zeros(n)
+@time it, x, sol = ProximalAlgorithms.PANOC(x0; fq=f, Aq=A, g=g, adaptive=true)
+@test vecnorm(x - x_star, Inf) <= 1e-4
+#@test it == 10
+println(sol)
+
 # Douglas-Rachford
 
 x0 = zeros(n)

--- a/test/test_lasso_small.jl
+++ b/test/test_lasso_small.jl
@@ -15,7 +15,7 @@ g = NormL1(lam)
 
 x_star = [-3.877278911564627e-01, 0, 0, 2.174149659863943e-02, 6.168435374149660e-01]
 
-# Nonfast/Nonadaptive
+## Nonfast/Nonadaptive
 
 x0 = zeros(n)
 @time it, x, sol = ProximalAlgorithms.FBS(x0; fq=f, Aq=A, g=g, gamma=1.0/norm(A)^2)
@@ -72,7 +72,7 @@ println(sol)
 #testing solver already at solution
 @time it, x = ProximalAlgorithms.run!(sol)
 
-# PANOC/Adaptive
+## PANOC/Adaptive
 
 x0 = zeros(n)
 @time it, x, sol = ProximalAlgorithms.PANOC(x0; fq=f, Aq=A, g=g, adaptive=true)

--- a/test/test_lasso_small_split_f.jl
+++ b/test/test_lasso_small_split_f.jl
@@ -23,7 +23,7 @@ x_star = [-3.877278911564627e-01, 0, 0, 2.174149659863943e-02, 6.168435374149660
 x0 = ProximalAlgorithms.blockzeros(x_star)
 @time it, x, sol = ProximalAlgorithms.FBS(x0; fq=f, Aq=opA, g=g, gamma=1.0/norm(A)^2)
 @test vecnorm(x .- x_star, Inf) <= 1e-4
-@test it == 140
+#@test it == 140
 println(sol)
 
 # Nonfast/Adaptive
@@ -31,7 +31,7 @@ println(sol)
 x0 = ProximalAlgorithms.blockzeros(x_star)
 @time it, x, sol = ProximalAlgorithms.FBS(x0; fq=f, Aq=opA, g=g, adaptive=true)
 @test vecnorm(x .- x_star, Inf) <= 1e-4
-@test it == 247
+#@test it == 247
 println(sol)
 
 # Fast/Nonadaptive
@@ -39,7 +39,7 @@ println(sol)
 x0 = ProximalAlgorithms.blockzeros(x_star)
 @time it, x, sol = ProximalAlgorithms.FBS(x0; fq=f, Aq=opA, g=g, gamma=1.0/norm(A)^2, fast=true)
 @test vecnorm(x .- x_star, Inf) <= 1e-4
-@test it == 94
+#@test it == 94
 println(sol)
 
 # Fast/Adaptive
@@ -47,7 +47,7 @@ println(sol)
 x0 = ProximalAlgorithms.blockzeros(x_star)
 @time it, x, sol = ProximalAlgorithms.FBS(x0; fq=f, Aq=opA, g=g, adaptive=true, fast=true)
 @test vecnorm(x .- x_star, Inf) <= 1e-4
-@test it == 156
+#@test it == 156
 println(sol)
 
 # ZeroFPR/Nonadaptive
@@ -55,7 +55,7 @@ println(sol)
 x0 = ProximalAlgorithms.blockzeros(x_star)
 @time it, x, sol = ProximalAlgorithms.ZeroFPR(x0; fq=f, Aq=opA, g=g, gamma=1.0/norm(A)^2)
 @test vecnorm(x - x_star, Inf) <= 1e-4
-@test it == 8
+#@test it == 8
 println(sol)
 
 # ZeroFPR/Adaptive
@@ -63,5 +63,5 @@ println(sol)
 x0 = ProximalAlgorithms.blockzeros(x_star)
 @time it, x, sol = ProximalAlgorithms.ZeroFPR(x0; fq=f, Aq=opA, g=g, adaptive=true)
 @test vecnorm(x - x_star, Inf) <= 1e-4
-@test it == 10
+#@test it == 10
 println(sol)

--- a/test/test_lasso_small_split_f.jl
+++ b/test/test_lasso_small_split_f.jl
@@ -23,7 +23,7 @@ x_star = [-3.877278911564627e-01, 0, 0, 2.174149659863943e-02, 6.168435374149660
 x0 = ProximalAlgorithms.blockzeros(x_star)
 @time it, x, sol = ProximalAlgorithms.FBS(x0; fq=f, Aq=opA, g=g, gamma=1.0/norm(A)^2)
 @test vecnorm(x .- x_star, Inf) <= 1e-4
-#@test it == 140
+@test it < 150
 println(sol)
 
 # Nonfast/Adaptive
@@ -31,7 +31,7 @@ println(sol)
 x0 = ProximalAlgorithms.blockzeros(x_star)
 @time it, x, sol = ProximalAlgorithms.FBS(x0; fq=f, Aq=opA, g=g, adaptive=true)
 @test vecnorm(x .- x_star, Inf) <= 1e-4
-#@test it == 247
+@test it < 300
 println(sol)
 
 # Fast/Nonadaptive
@@ -39,7 +39,7 @@ println(sol)
 x0 = ProximalAlgorithms.blockzeros(x_star)
 @time it, x, sol = ProximalAlgorithms.FBS(x0; fq=f, Aq=opA, g=g, gamma=1.0/norm(A)^2, fast=true)
 @test vecnorm(x .- x_star, Inf) <= 1e-4
-#@test it == 94
+@test it < 100
 println(sol)
 
 # Fast/Adaptive
@@ -47,7 +47,7 @@ println(sol)
 x0 = ProximalAlgorithms.blockzeros(x_star)
 @time it, x, sol = ProximalAlgorithms.FBS(x0; fq=f, Aq=opA, g=g, adaptive=true, fast=true)
 @test vecnorm(x .- x_star, Inf) <= 1e-4
-#@test it == 156
+@test it < 200
 println(sol)
 
 # ZeroFPR/Nonadaptive
@@ -55,7 +55,7 @@ println(sol)
 x0 = ProximalAlgorithms.blockzeros(x_star)
 @time it, x, sol = ProximalAlgorithms.ZeroFPR(x0; fq=f, Aq=opA, g=g, gamma=1.0/norm(A)^2)
 @test vecnorm(x - x_star, Inf) <= 1e-4
-#@test it == 8
+@test it < 15
 println(sol)
 
 # ZeroFPR/Adaptive
@@ -63,14 +63,14 @@ println(sol)
 x0 = ProximalAlgorithms.blockzeros(x_star)
 @time it, x, sol = ProximalAlgorithms.ZeroFPR(x0; fq=f, Aq=opA, g=g, adaptive=true)
 @test vecnorm(x - x_star, Inf) <= 1e-4
-#@test it == 10
+@test it < 20
 
 # PANOC/Nonadaptive
 
 x0 = ProximalAlgorithms.blockzeros(x_star)
 @time it, x, sol = ProximalAlgorithms.PANOC(x0; fq=f, Aq=opA, g=g, gamma=1.0/norm(A)^2)
 @test vecnorm(x - x_star, Inf) <= 1e-4
-#@test it == 8
+@test it < 20
 println(sol)
 
 # PANOC/Adaptive
@@ -78,5 +78,5 @@ println(sol)
 x0 = ProximalAlgorithms.blockzeros(x_star)
 @time it, x, sol = ProximalAlgorithms.PANOC(x0; fq=f, Aq=opA, g=g, adaptive=true)
 @test vecnorm(x - x_star, Inf) <= 1e-4
-#@test it == 10
+@test it < 20
 println(sol)

--- a/test/test_lasso_small_split_f.jl
+++ b/test/test_lasso_small_split_f.jl
@@ -65,3 +65,19 @@ x0 = ProximalAlgorithms.blockzeros(x_star)
 @test vecnorm(x - x_star, Inf) <= 1e-4
 #@test it == 10
 println(sol)
+
+# PANOC/Nonadaptive
+
+x0 = ProximalAlgorithms.blockzeros(x_star)
+@time it, x, sol = ProximalAlgorithms.PANOC(x0; fq=f, Aq=opA, g=g, gamma=1.0/norm(A)^2)
+@test vecnorm(x - x_star, Inf) <= 1e-4
+#@test it == 8
+println(sol)
+
+# PANOC/Adaptive
+
+x0 = ProximalAlgorithms.blockzeros(x_star)
+@time it, x, sol = ProximalAlgorithms.PANOC(x0; fq=f, Aq=opA, g=g, adaptive=true)
+@test vecnorm(x - x_star, Inf) <= 1e-4
+#@test it == 10
+println(sol)

--- a/test/test_lasso_small_split_x.jl
+++ b/test/test_lasso_small_split_x.jl
@@ -30,7 +30,7 @@ x_star = ([-3.877278911564627e-01, 0, 0], [2.174149659863943e-02, 6.168435374149
 x0 = ProximalAlgorithms.blockzeros(x_star)
 @time it, x, sol = ProximalAlgorithms.FBS(x0; fq=f, Aq=opA, g=g, gamma=1.0/norm(A)^2)
 @test ProximalAlgorithms.blockmaxabs(x .- x_star) <= 1e-4
-#@test it == 140
+@test it < 150
 println(sol)
 
 # Nonfast/Adaptive
@@ -38,7 +38,7 @@ println(sol)
 x0 = ProximalAlgorithms.blockzeros(x_star)
 @time it, x, sol = ProximalAlgorithms.FBS(x0; fq=f, Aq=opA, g=g, adaptive=true)
 @test ProximalAlgorithms.blockmaxabs(x .- x_star) <= 1e-4
-#@test it == 247
+@test it < 300
 println(sol)
 
 # Fast/Nonadaptive
@@ -46,7 +46,7 @@ println(sol)
 x0 = ProximalAlgorithms.blockzeros(x_star)
 @time it, x, sol = ProximalAlgorithms.FBS(x0; fq=f, Aq=opA, g=g, gamma=1.0/norm(A)^2, fast=true)
 @test ProximalAlgorithms.blockmaxabs(x .- x_star) <= 1e-4
-#@test it == 94
+@test it < 100
 println(sol)
 
 # Fast/Adaptive
@@ -54,7 +54,7 @@ println(sol)
 x0 = ProximalAlgorithms.blockzeros(x_star)
 @time it, x, sol = ProximalAlgorithms.FBS(x0; fq=f, Aq=opA, g=g, adaptive=true, fast=true)
 @test ProximalAlgorithms.blockmaxabs(x .- x_star) <= 1e-4
-#@test it == 156
+@test it < 200
 println(sol)
 
 # ZeroFPR/Adaptive
@@ -62,7 +62,7 @@ println(sol)
 x0 = ProximalAlgorithms.blockzeros(x_star)
 @time it, x, sol = ProximalAlgorithms.ZeroFPR(x0; fq=f, Aq=opA, g=g, adaptive=true)
 @test ProximalAlgorithms.blockmaxabs(x .- x_star) <= 1e-4
-#@test it == 10
+@test it < 15
 println(sol)
 
 # PANOC/Adaptive
@@ -70,5 +70,5 @@ println(sol)
 x0 = ProximalAlgorithms.blockzeros(x_star)
 @time it, x, sol = ProximalAlgorithms.PANOC(x0; fq=f, Aq=opA, g=g, adaptive=true)
 @test ProximalAlgorithms.blockmaxabs(x .- x_star) <= 1e-4
-#@test it == 10
+@test it < 20
 println(sol)

--- a/test/test_lasso_small_split_x.jl
+++ b/test/test_lasso_small_split_x.jl
@@ -30,7 +30,7 @@ x_star = ([-3.877278911564627e-01, 0, 0], [2.174149659863943e-02, 6.168435374149
 x0 = ProximalAlgorithms.blockzeros(x_star)
 @time it, x, sol = ProximalAlgorithms.FBS(x0; fq=f, Aq=opA, g=g, gamma=1.0/norm(A)^2)
 @test ProximalAlgorithms.blockmaxabs(x .- x_star) <= 1e-4
-@test it == 140
+#@test it == 140
 println(sol)
 
 # Nonfast/Adaptive
@@ -38,7 +38,7 @@ println(sol)
 x0 = ProximalAlgorithms.blockzeros(x_star)
 @time it, x, sol = ProximalAlgorithms.FBS(x0; fq=f, Aq=opA, g=g, adaptive=true)
 @test ProximalAlgorithms.blockmaxabs(x .- x_star) <= 1e-4
-@test it == 247
+#@test it == 247
 println(sol)
 
 # Fast/Nonadaptive
@@ -46,7 +46,7 @@ println(sol)
 x0 = ProximalAlgorithms.blockzeros(x_star)
 @time it, x, sol = ProximalAlgorithms.FBS(x0; fq=f, Aq=opA, g=g, gamma=1.0/norm(A)^2, fast=true)
 @test ProximalAlgorithms.blockmaxabs(x .- x_star) <= 1e-4
-@test it == 94
+#@test it == 94
 println(sol)
 
 # Fast/Adaptive
@@ -54,7 +54,7 @@ println(sol)
 x0 = ProximalAlgorithms.blockzeros(x_star)
 @time it, x, sol = ProximalAlgorithms.FBS(x0; fq=f, Aq=opA, g=g, adaptive=true, fast=true)
 @test ProximalAlgorithms.blockmaxabs(x .- x_star) <= 1e-4
-@test it == 156
+#@test it == 156
 println(sol)
 
 # ZeroFPR/Adaptive
@@ -62,6 +62,5 @@ println(sol)
 x0 = ProximalAlgorithms.blockzeros(x_star)
 @time it, x, sol = ProximalAlgorithms.ZeroFPR(x0; fq=f, Aq=opA, g=g, adaptive=true)
 @test ProximalAlgorithms.blockmaxabs(x .- x_star) <= 1e-4
-@test it == 10
+#@test it == 10
 println(sol)
-

--- a/test/test_lasso_small_split_x.jl
+++ b/test/test_lasso_small_split_x.jl
@@ -64,3 +64,11 @@ x0 = ProximalAlgorithms.blockzeros(x_star)
 @test ProximalAlgorithms.blockmaxabs(x .- x_star) <= 1e-4
 #@test it == 10
 println(sol)
+
+# PANOC/Adaptive
+
+x0 = ProximalAlgorithms.blockzeros(x_star)
+@time it, x, sol = ProximalAlgorithms.PANOC(x0; fq=f, Aq=opA, g=g, adaptive=true)
+@test ProximalAlgorithms.blockmaxabs(x .- x_star) <= 1e-4
+#@test it == 10
+println(sol)


### PR DESCRIPTION
Added first draft of `PANOC`.

I've also changed the iterator structure of the solvers. In fact currently if first iterate is already at the solution there is a crash. 
The problem was in the `run` function:
```julia
function run(solver::ProximalAlgorithm{I, T})::Tuple{I, T} where {I, T}
    local it, point
    if verbose(solver) display(solver) end
    # NOTE: the following loop is translated into:
    #   it = start(solver)
    #   while !done(solver, it)
    #       (point, it) = next(solver, it)
    #       [...]
    #   end
    # See: https://docs.julialang.org/en/stable/manual/interfaces
    for (it, point) in enumerate(solver)
        if verbose(solver, it) display(solver, it) end
    end
    if verbose(solver) display(solver, it) end
    return (it, point)
end
```  
 `done` already gives a `true` and `point` is never initialized.

I don't see why these iterators should have a  _state_, so I've changed this into a `Void` status:
```julia
function run!(solver::ProximalAlgorithm{I})::I where {I}
    local it = zero(I)
    local point = nothing
    if verbose(solver) display(solver) end
    # NOTE: the following loop is translated into:
    #   it = start(solver)
    #   while !done(solver, it)
    #       (point, it) = next(solver, it)
    #       [...]
    #   end
    # See: https://docs.julialang.org/en/stable/manual/interfaces
    for (it, point) in enumerate(solver)
        if verbose(solver, it) display(solver, it) end
    end
    if verbose(solver) display(solver, it) end
    return it
end
```
As a consequence the abstract type `ProximalAlgorithm{I}` has now a single field.

Other minor stuff changed:
* `initialize`, `iterate`, `run`, changed to `initialize!`, `iterate!`, `run!`
* added interfaces that do not initialize solvers e.g. `FBS!`, `ZeroFPR!` etc 