### PR TITLE
type stable FBSolvers + complex variables tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Douglas-Rachford splitting algorithm  | [`DRS`](src/algorithms/DouglasRachford.j
 Forward-backward splitting (i.e. proximal gradient) algorithm | [`FBS`](src/algorithms/ForwardBackward.jl) | [[2]][tseng_2008], [[3]][beck_2009]
 Vũ-Condat primal-dual algorithm       | [`VuCondat`](src/algorithms/AsymmetricForwardBackwardAdjoint.jl) | [[6]][vu_2013], [[7]][condat_2013]
 ZeroFPR (L-BFGS)                      | [`ZeroFPR`](src/algorithms/ZeroFPR.jl) | [[9]][themelis_2016]
+PANOC (L-BFGS)                        | [`PANOC`](src/algorithms/PANOC.jl) | [[11]][stella_2017]
 
 ### Contributing
 
@@ -51,6 +52,8 @@ Contributions are welcome in the form of [issues notification](https://github.co
 
 [[10]][latafat_2017] Latafat, Patrinos, *Asymmetric forward–backward–adjoint splitting for solving monotone inclusions involving three operators*, Computational Optimization and Applications, vol. 68, no. 1, pp. 57-93 (2017).
 
+[[11]][stella_2017] Stella, Themelis, Sopasakis, Patrinos, *A simple and efficient algorithm for nonlinear model predictive control*, 56th IEEE Conference on Decision and Control (2017).
+
 [eckstein_1989]: https://link.springer.com/article/10.1007/BF01581204
 [tseng_2008]: http://www.mit.edu/~dimitrib/PTseng/papers/apgm.pdf
 [beck_2009]: http://epubs.siam.org/doi/abs/10.1137/080716542
@@ -59,5 +62,6 @@ Contributions are welcome in the form of [issues notification](https://github.co
 [parikh_2014]: http://www.nowpublishers.com/article/Details/OPT-003
 [themelis_2016]: https://arxiv.org/abs/1606.06256
 [latafat_2017]: https://link.springer.com/article/10.1007/s10589-017-9909-6
+[stella_2017]: https://doi.org/10.1109/CDC.2017.8263933
 [condat_2013]: https://link.springer.com/article/10.1007/s10957-012-0245-9
 [vu_2013]: https://link.springer.com/article/10.1007/s10444-011-9254-8

--- a/test/test_l1logreg_small.jl
+++ b/test/test_l1logreg_small.jl
@@ -45,3 +45,4 @@ x0 = zeros(n)
 @test vecnorm(x - x_star, Inf) <= 1e-4
 @test it < 35
 println(sol)
+

--- a/test/test_lasso_harder.jl
+++ b/test/test_lasso_harder.jl
@@ -35,3 +35,48 @@ x0 = zeros(n)
 
 @test norm(xP-xZ) < 1e-8
 @test it < 300
+
+#####################
+# Complex Variables #
+#####################
+
+srand(123)
+m, n = 10,100
+
+A = randn(m,n)+im*randn(m,n)
+U,S,V = svd(A)
+#create ill conditioned matrix 
+S[floor(Int,0.5*min(m,n)):end] .= 0.
+A = U*diagm(S)*V'
+
+x_star = sprandn(n,0.5).+im.*sprandn(n,0.5)
+b = A*x_star+20*(randn(m).+im*randn(m))
+
+f = Translate(SqrNormL2(), -b)
+f2 = LeastSquares(A, b)
+lam = 1e-2*vecnorm(A'*b, Inf)
+g = NormL1(lam)
+
+x0 = zeros(n)+im*zeros(n)
+it, x_star, sol = ProximalAlgorithms.PANOC(x0; fq=f, Aq=A, g=g, verbose = 0, tol = 1e-9)
+
+# fast FBS/Adaptive
+x0 = zeros(n)+im*zeros(n)
+@time it, x, sol = ProximalAlgorithms.FBS(x0; fq=f, Aq=A, g=g, fast = true, tol = 1e-6, maxit = 30000)
+
+@test norm(x-x_star) < 1e-4
+@test it < 23000
+
+# ZeroFPR/Adaptive
+x0 = zeros(n)+im*zeros(n)
+@time it, x, sol = ProximalAlgorithms.ZeroFPR(x0; fq=f, Aq=A, g=g, tol = 1e-6)
+
+@test norm(x-x_star) < 1e-4
+@test it < 400
+
+# PANOC/Adaptive
+x0 = zeros(n)+im*zeros(n)
+@time it, x, sol = ProximalAlgorithms.PANOC(x0; fq=f, Aq=A, g=g, tol = 1e-6)
+
+@test norm(x-x_star) < 1e-4
+@test it < 1200

--- a/test/test_lasso_small.jl
+++ b/test/test_lasso_small.jl
@@ -105,3 +105,155 @@ println(sol)
 #testing solver already at solution
 @time it, x = ProximalAlgorithms.run!(sol)
 @test it == 1
+
+#####################
+# Complex Variables #
+#####################
+
+srand(123)
+m, n = 10,5
+
+A = randn(m,n)+im*randn(m,n)
+b = randn(m)+im*randn(m)
+
+f = Translate(SqrNormL2(), -b)
+f2 = LeastSquares(A, b)
+lam = 0.01*vecnorm(A'*b, Inf)
+g = NormL1(lam)
+
+x0 = zeros(n)+im*zeros(n)
+it, x_star, sol = ProximalAlgorithms.PANOC(x0; fq=f, Aq=A, g=g, gamma=1.0/norm(A)^2, verbose = 0)
+
+## Nonfast/Nonadaptive
+
+x0 = zeros(n)+im*zeros(n)
+@time it, x, sol = ProximalAlgorithms.FBS(x0; fq=f, Aq=A, g=g, gamma=1.0/norm(A)^2)
+@test vecnorm(x - x_star, Inf) <= 1e-4
+@test it < 200
+println(sol)
+
+# testing solver already at solution
+@time it, x = ProximalAlgorithms.run!(sol)
+@test it == 1
+
+# Nonfast/Adaptive
+
+x0 = zeros(n)+im*zeros(n)
+@time it, x, sol = ProximalAlgorithms.FBS(x0; fq=f, Aq=A, g=g, adaptive=true)
+@test vecnorm(x - x_star, Inf) <= 1e-4
+@test it < 250
+println(sol)
+
+# Fast/Nonadaptive
+
+x0 = zeros(n)+im*zeros(n)
+@time it, x, sol = ProximalAlgorithms.FBS(x0; fq=f, Aq=A, g=g, gamma=1.0/norm(A)^2, fast=true)
+@test vecnorm(x - x_star, Inf) <= 1e-4
+@test it < 120
+println(sol)
+
+# testing solver already at solution
+@time it, x = ProximalAlgorithms.run!(sol)
+@test it == 1
+
+# Fast/Adaptive
+
+x0 = zeros(n)+im*zeros(n)
+@time it, x, sol = ProximalAlgorithms.FBS(x0; fq=f, Aq=A, g=g, adaptive=true, fast=true)
+@test vecnorm(x - x_star, Inf) <= 1e-4
+@test it < 120
+println(sol)
+
+# ZeroFPR/Nonadaptive
+
+x0 = zeros(n)+im*zeros(n)
+@time it, x, sol = ProximalAlgorithms.ZeroFPR(x0; fq=f, Aq=A, g=g, gamma=1.0/norm(A)^2)
+@test vecnorm(x - x_star, Inf) <= 1e-4
+@test it < 15
+println(sol)
+
+#testing solver already at solution
+@time it, x = ProximalAlgorithms.run!(sol)
+@test it == 1
+
+# ZeroFPR/Adaptive
+
+x0 = zeros(n)+im*zeros(n)
+@time it, x, sol = ProximalAlgorithms.ZeroFPR(x0; fq=f, Aq=A, g=g, adaptive=true)
+@test vecnorm(x - x_star, Inf) <= 1e-4
+@test it < 15
+
+# PANOC/Nonadaptive
+
+x0 = zeros(n)+im*zeros(n)
+@time it, x, sol = ProximalAlgorithms.PANOC(x0; fq=f, Aq=A, g=g, gamma=1.0/norm(A)^2)
+@test vecnorm(x - x_star, Inf) <= 1e-4
+@test it < 20
+println(sol)
+
+# testing solver already at solution
+@time it, x = ProximalAlgorithms.run!(sol)
+@test it == 1
+
+## PANOC/Adaptive
+
+x0 = zeros(n)+im*zeros(n)
+@time it, x, sol = ProximalAlgorithms.PANOC(x0; fq=f, Aq=A, g=g, adaptive=true)
+@test vecnorm(x - x_star, Inf) <= 1e-4
+@test it < 20
+println(sol)
+
+#############################################
+# Real Variables  mapped to Complex Numbers #
+#############################################
+
+using AbstractOperators
+
+srand(123)
+n = 2^6
+A = DFT(n)[1:div(n,2)]      # overcomplete dictionary 
+
+x = sprandn(n,0.5)
+b = fft(x)[1:div(n,2)]
+
+#f = Translate(LogisticLoss(ones(n)), -b)
+f = Translate(SqrNormL2(), -b)
+lam = 0.01*norm(A'*b,Inf)
+g = NormL1(lam)
+
+x0 = zeros(n)
+it, x_star, sol = ProximalAlgorithms.PANOC(x0; fq=f, Aq=A, g=g, verbose = 0, tol = 1e-8)
+
+# Nonfast/Adaptive
+
+x0 = zeros(n)
+@time it, x, sol = ProximalAlgorithms.FBS(x0; fq=f, Aq=A, g=g, tol=1e-6, adaptive=true)
+@test vecnorm(x - x_star, Inf) <= 1e-4
+@test it < 50
+println(sol)
+
+# Fast/Adaptive
+
+x0 = zeros(n)
+@time it, x, sol = ProximalAlgorithms.FBS(x0; fq=f, Aq=A, g=g, tol=1e-6, adaptive=true, fast=true)
+@test vecnorm(x - x_star, Inf) <= 1e-4
+@test it < 50
+println(sol)
+
+# ZeroFPR/Adaptive
+
+x0 = zeros(n)
+@time it, x, sol = ProximalAlgorithms.ZeroFPR(x0; fq=f, Aq=A, g=g, tol=1e-6, adaptive=true)
+@test vecnorm(x - x_star, Inf) <= 1e-4
+@test it < 15
+println(sol)
+
+# PANOC/Adaptive
+
+x0 = zeros(n)
+@time it, x, sol = ProximalAlgorithms.PANOC(x0; fq=f, Aq=A, g=g, tol=1e-6, adaptive=true)
+@test vecnorm(x - x_star, Inf) <= 1e-4
+@test it < 20
+println(sol)
+
+


### PR DESCRIPTION
Made type stable solvers: as discussed in #8, this is achieved by inferring the data type of the output of the operators `Aq` and `As` by multiplying them with `x0` inside the constructor of the iterators. This leaves the constructor calls untouched.  

Moreover, the FB solvers are now working with complex variables. Tests have been added. 

Finally references have been added in `README.md` for `PANOC`.

Hopefully vim should have avoided tabs! :rofl: 
